### PR TITLE
Add requirements.txt for easy pip install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+dnspython
+netaddr
+pybonjour


### PR DESCRIPTION
The `requirements.txt` file makes it easy for users to install the necessary modules for the script with a simple `pip install -r requirements.txt`.