### PR TITLE
Add requirements.txt for easy pip install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+dnspython
+netaddr


### PR DESCRIPTION
The requirements.txt file makes it easy for users to install the necessary modules for the script with a simple `pip install -r requirements.txt`. For a Python 3 install you would specify `pip3`.

    pip install -r requirements.txt
    pip3 install -r requirements.txt