### PR TITLE
Fix serialization to json for NSEC next attribute

### DIFF
--- a/lib/dnshelper.py
+++ b/lib/dnshelper.py
@@ -652,7 +652,7 @@ class DnsHelper:
                         for rdata in rdataset:
                             print_status('\t NSEC {0}'.format(rdata.next))
                             zone_records.append({'zone_server': ns_srv, 'type': 'NSEC',
-                                                 'next': rdata.next})
+                                                 'next': rdata.next.to_text()})
 
                     for (name, rdataset) in zone.iterate_rdatasets(dns.rdatatype.NSEC3):
                         for rdata in rdataset:


### PR DESCRIPTION
This change fixes serialization to json issue for the following command:

root@kali:~# dnsrecon -d zonetransfer.me -t axfr -j ./zonetransfer_axfr.json

Below is output from console for error that has been fixed:

[*] Testing NS Servers for Zone Transfer
[*] Checking for Zone Transfer for zonetransfer.me name servers
...
[*] Saving records to JSON file: ./zonetransfer_axfr.json
Traceback (most recent call last):
  File "./dnsrecon.py", line 1685, in <module>
    main()
  File "./dnsrecon.py", line 1635, in main
    write_json(json_file, returned_records, scan_info)
  File "./dnsrecon.py", line 778, in write_json
    json_data = json.dumps(data, sort_keys=True, indent=4, separators=(',', ': '))
  File "/usr/lib/python2.7/json/__init__.py", line 251, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 209, in encode
    chunks = list(chunks)
  File "/usr/lib/python2.7/json/encoder.py", line 431, in _iterencode
    for chunk in _iterencode_list(o, _current_indent_level):
  File "/usr/lib/python2.7/json/encoder.py", line 332, in _iterencode_list
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/usr/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <DNS name _sip._tcp> is not JSON serializable
root@kali:~# 