### PR TITLE
Fix for issue #53: Added enumeration type checking before scan

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -530,7 +530,7 @@ def scrape_google(dom):
         data += sock.read()
         if re.search('Our systems have detected unusual traffic from your computer network',data) != None:
           print_error("Google has detected the search as \'bot activity, stopping search...")
-          return 
+          return
         sock.close()
     results.extend(unique(re.findall("htt\w{1,2}:\/\/([^:?]*[a-b0-9]*[^:?]*\." + dom + ")\/", data)))
 
@@ -1505,11 +1505,19 @@ def main():
     domain_req = ['axfr', 'std', 'srv', 'tld', 'goo', 'zonewalk']
     scan_info = [" ".join(sys.argv), str(datetime.datetime.now())]
 
+    # Check for any illegal enumeration types from the user
+    valid_types = ['axfr','std','rvl','brt','srv','tld','goo','snoop','zonewalk']
+    incorrect_types = [t for t in type.split(',') if t not in valid_types]
+    if incorrect_types:
+        print_error("This type of scan is not in the list: {0}".format(','.join(incorrect_types)))
+        sys.exit(1)
+
     if type is not None:
         for r in type.split(','):
             if r in domain_req and domain is None:
                 print_error('No Domain to target specified!')
                 sys.exit(1)
+
             try:
                 if r == 'axfr':
                     print_status('Testing NS Servers for Zone Transfer')
@@ -1596,7 +1604,7 @@ def main():
                         ds_zone_walk(res, domain)
 
                 else:
-                    print_error("This type of scan is not in the list {0}".format(r))
+                    print_error("This type of scan is not in the list: {0}".format(r))
 
             except dns.resolver.NXDOMAIN:
                 print_error("Could not resolve domain: {0}".format(domain))


### PR DESCRIPTION
Issue #53 bit me a few times so put together a quick PR. `dnsrecon.py` now checks enumeration types requested by the user before performing the scan.

So now when you provide an incorrect enumeration type:
`$ python dnsrecon.py -t std,afxr,qqqq -d twitter.com`
`[-] This type of scan is not in the list: afxr,qqqq`
`$ python dnsrecon.py -t std,afxr -d twitter.com`
`[-] This type of scan is not in the list: afxr`

Correctly typed scans work the same:
`$ python dnsrecon.py -t std -d twitter.com`
`[*] Performing General Enumeration of Domain:`
`[-] DNSSEC is not configured for twitter.com`
`[*] 	 SOA ns1.p26.dynect.net 208.78.70.26`
`[*] 	 NS ns2.p34.dynect.net 204.13.250.34`
`[*] 	 Bind Version for 204.13.250.34 9.10.4-P3.0`

Only a few quick lines of code, code review should be easy :)
Not sure what the change of removing and adding back line 533 is about, Atom being weird.. The meat is just lines 1508-1513.

Cheers
@decidedlygray

