### PR TITLE
fixing issue-53-fix. not providing -t flag now works correctly

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1505,14 +1505,15 @@ def main():
     domain_req = ['axfr', 'std', 'srv', 'tld', 'goo', 'zonewalk']
     scan_info = [" ".join(sys.argv), str(datetime.datetime.now())]
 
-    # Check for any illegal enumeration types from the user
-    valid_types = ['axfr','std','rvl','brt','srv','tld','goo','snoop','zonewalk']
-    incorrect_types = [t for t in type.split(',') if t not in valid_types]
-    if incorrect_types:
-        print_error("This type of scan is not in the list: {0}".format(','.join(incorrect_types)))
-        sys.exit(1)
-
     if type is not None:
+
+        # Check for any illegal enumeration types from the user
+        valid_types = ['axfr','std','rvl','brt','srv','tld','goo','snoop','zonewalk']
+        incorrect_types = [t for t in type.split(',') if t not in valid_types]
+        if incorrect_types:
+            print_error("This type of scan is not in the list: {0}".format(','.join(incorrect_types)))
+            sys.exit(1)
+
         for r in type.split(','):
             if r in domain_req and domain is None:
                 print_error('No Domain to target specified!')


### PR DESCRIPTION
As noticed by some other users, my previous fix for #53 introduced a bug. This fixes the bug by moving the enumeration type checking to *after* checking whether the user actually provided a type (-t).