### PR TITLE
Fixed multiple exceptions.

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -853,7 +853,6 @@ def dns_sec_check(domain, res):
     
     except dns.resolver.NoNameservers:
         print_error("All nameservers failed to answer the DNSSEC query for {0}".format(domain))
-        sys.exit(1)
 
     except dns.exception.Timeout:
         print_error("A timeout error occurred please make sure you can reach the target DNS Servers")

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -732,6 +732,8 @@ def make_csv(data):
                 csv_data += n["type"] + "," + n["name"] + "," + n["address"] + "," + n["target"] + "," + n["port"] + "\n"
 
             elif re.search(r"CNAME", n["type"]):
+                if "target" not in n.keys():
+                    n["target"] = ""
                 csv_data += n["type"] + "," + n["name"] + ",," + n["target"] + ",\n"
 
             else:

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -850,6 +850,10 @@ def dns_sec_check(domain, res):
     except dns.resolver.NXDOMAIN:
         print_error("Could not resolve domain: {0}".format(domain))
         sys.exit(1)
+    
+    except dns.resolver.NoNameservers:
+        print_error("All nameservers failed to answer the DNSSEC query for {0}".format(domain))
+        sys.exit(1)
 
     except dns.exception.Timeout:
         print_error("A timeout error occurred please make sure you can reach the target DNS Servers")


### PR DESCRIPTION
Hi Carlos,

I have encountered multiple exceptions when using dnsrecon.

The first exception occurs when running dnsrecon with `-t zonewalk`. When a dnsreolver fails to answer the query, an exception occurs as the following:

```
Traceback (most recent call last):
  File "./dnsrecon.py", line 1665, in <module>
    main()
  File "./dnsrecon.py", line 1502, in main
    std_enum_records = general_enum(res, domain, xfr, goo, bing, spf_enum, do_whois, zonewalk)
  File "./dnsrecon.py", line 933, in general_enum
    dns_sec_check(domain, res)
  File "./dnsrecon.py", line 836, in dns_sec_check
    answer = res._res.query(domain, 'DNSKEY')
  File "/usr/local/lib/python2.7/dist-packages/dns/resolver.py", line 947, in query
    raise NoNameservers(request=request, errors=errors)
dns.resolver.NoNameservers: All nameservers failed to answer the query [DOMAIN-redacted]. IN DNSKEY: Server 8.8.8.8 UDP port 53 answered SERVFAIL; Server 8.8.4.4 UDP port 53 answered SERVFAIL

```

The second exception occurs because of calling a key that does not exists on the dict. I'm not sure why, but I have made a fix for it.

Here is the exception:
```
Traceback (most recent call last):
  File "./dnsrecon.py", line 1665, in <module>
    main()
  File "./dnsrecon.py", line 1642, in main
    write_to_file(make_csv(returned_records), csv_file)
  File "./dnsrecon.py", line 735, in make_csv
    csv_data += n["type"] + "," + n["name"] + ",," + n["target"] + ",\n"
KeyError: 'target'

```

I have tested and verified that the changes fixes the exceptions that was occurring.
