### PR TITLE
Do not print usage twice when --help is passed.

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1419,10 +1419,13 @@ def main():
         parser.add_argument("-v", help="Enable verbose", action="store_true")
         arguments = parser.parse_args()
 
+    except SystemExit:
+        # Handle exit() from passing --help
+        raise
     except:
         print_error("Wrong Option Provided!")
         parser.print_help()
-        sys.exit(0)
+        sys.exit(1)
     #
     # Parse options
     #
@@ -1684,7 +1687,7 @@ def main():
             sys.exit(1)
     else:
         usage()
-        sys.exit(0)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Passing --help currently causes the usage to be printed twice.  This will prevent that, allowing the SystemExit exception to bubble up without printing a 2nd usage.

It also changes exit codes to 1 on cases that would be considered an error (invalid flags, etc.) so scripts can more easily detect failure cases.