### PR TITLE
Handled exception for dns.resolver.NoNameservers

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -970,6 +970,9 @@ def general_enum(res, domain, do_axfr, do_google, do_bing, do_spf, do_whois, do_
 
         except dns.resolver.NoAnswer:
             print_error("Could not Resolve NS Records for {0}".format(domain))
+        except dns.resolver.NoNameservers:
+            print_error("All nameservers failed to answer the NS query for {0}".format(domain))
+            sys.exit(1)
 
         # Enumerate MX Records
         try:
@@ -1694,4 +1697,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary

When an NS query does not return nameservers, this exception is raised. However, it was not handled, which led to the crash of the program.

This commit handles this exception.