### PR TITLE
Return empty soa_record if no response

### DIFF
--- a/lib/dnshelper.py
+++ b/lib/dnshelper.py
@@ -212,6 +212,8 @@ class DnsHelper:
                 answers = response.answer
             elif len(response.authority) > 0:
                 answers = response.authority
+            else:
+                return soa_records
             for rdata in answers:
                 # A zone only has one SOA record so we select the first.
                 name = rdata[0].mname.to_text()


### PR DESCRIPTION
Instead of having an unhandled exception terminate dnsrecon when trying to loop over unset answers, return empty soa_record when there is no response, so that recon can continue.