### PR TITLE
Handle NS failure during MX lookup

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -986,6 +986,8 @@ def general_enum(res, domain, do_axfr, do_google, do_bing, do_spf, do_whois, do_
 
         except dns.resolver.NoAnswer:
             print_error("Could not Resolve MX Records for {0}".format(domain))
+        except dns.resolver.NoNameservers:
+            print_error("All nameservers failed to answer the MX query for {0}".format(domain))
 
         # Enumerate A Record for the targeted Domain
         for a_rcrd in res.get_ip(domain):


### PR DESCRIPTION
This PR handles an odd issue where the code can enumerate name servers for a target domain but where the DNS servers `dnsrecon` is using return a `SERVFAIL` message when trying to get the MX records. 

When this error is hit the code currently generates an exception and then exits. This PR allows the error to be gracefully handled so that we can collect other data.

This is currently reproducible against Cloudflare's `1.1.1.1` DNS servers. Other providers return a response to MX lookups but Cloudflare returns `SERVFAIL`

Reproduce failure:
`./dnsrecon.py -v -n 1.1.1.1 -t std -d  45111.link`

Reproduce response outside of `dnsrecon`
`dig @1.1.1.1 NS 45111.link`

Exception
```
$ ./dnsrecon.py -v -n 1.1.1.1 -t std -d  45111.link
[*] Performing General Enumeration of Domain:45111.link
[-] DNSSEC is not configured for 45111.link
[*]      SOA ns1.serverbr8.com 189.113.168.202
[*]      NS ns2.serverbr8.com 189.113.168.203
[*]      NS ns1.serverbr8.com 189.113.168.202
Traceback (most recent call last):
  File "/home/UserName/git/dnsrecon/dnsrecon.py", line 1699, in <module>
    main()
  File "/home/UserName/git/dnsrecon/dnsrecon.py", line 1530, in main
    std_enum_records = general_enum(res, domain, xfr, goo, bing, spf_enum, do_whois, do_crt, zonewalk)
  File "/home/UserName/git/dnsrecon/dnsrecon.py", line 979, in general_enum
    for mx_rcrd in res.get_mx():
  File "/home/UserName/git/dnsrecon/lib/dnshelper.py", line 150, in get_mx
    answers = self._res.query(self._domain, 'MX', tcp=tcp)
  File "/home/UserName/.local/lib/python2.7/site-packages/dns/resolver.py", line 898, in query
    raise NoNameservers(request=request, errors=errors)
dns.resolver.NoNameservers: All nameservers failed to answer the query 45111.link. IN MX: Server 1.1.1.1 UDP port 53 answered SERVFAIL
```