### PR TITLE
Handle socket exception in ds_zone_walk

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1304,6 +1304,9 @@ def ds_zone_walk(res, domain):
         print_error("are not being filtered. Increase the timeout to a higher number")
         print_error("with --lifetime <time> option.")
 
+    except (socket.error):
+        print_error("SoA nameserver {} failed to answer the DNSSEC query for {}".format(nameserver, domain))
+
     # Give a summary of the walk
     if len(records) > 0:
         print_good("{0} records found".format(len(records)))


### PR DESCRIPTION
This PR addresses an issue when the SoA server doesn't respond or is filtered during a zone walk.  This can cause `socket.error` exceptions which terminate the script and prevents other other data that was collected from being saved.

Reproducer
```
./dnsrecon.py -v -n 1.1.1.1  -t zonewalk -v -d thepaper.cn
./dnsrecon.py -v -n 1.1.1.1  -t zonewalk -v -d taobao.com
```

```
./dnsrecon.py -v -n 1.1.1.1  -t zonewalk -v -d thepaper.cn
[*] Performing NSEC Zone Walk for thepaper.cn
[*] Getting SOA record for thepaper.cn
[*] Name Server 47.88.44.151 will be used
[*] 	 A thepaper.cn 139.196.3.150
Traceback (most recent call last):
  File "./dnsrecon.py", line 1699, in <module>
    main()
  File "./dnsrecon.py", line 1614, in main
    ds_zone_walk(res, domain)
  File "./dnsrecon.py", line 1283, in ds_zone_walk
    response = get_a_answer(res, target, nameserver, timeout)
  File "./dnsrecon.py", line 1207, in get_a_answer
    answer = res.query(query, ns, timeout)
  File "/Users/UserName/git/working_forks/dnsrecon/lib/dnshelper.py", line 80, in query
    return dns.query.tcp(q, where, timeout, port, af, source, source_port, one_rr_per_rrset)
  File "/usr/local/lib/python2.7/site-packages/dns/query.py", line 489, in tcp
    send_tcp(s, wire, expiration)
  File "/usr/local/lib/python2.7/site-packages/dns/query.py", line 390, in send_tcp
    _net_write(sock, tcpmsg, expiration)
  File "/usr/local/lib/python2.7/site-packages/dns/query.py", line 364, in _net_write
    current += sock.send(data[current:])
socket.error: [Errno 32] Broken pipe

```