### PR TITLE
Change transformation logic

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1252,10 +1252,10 @@ def ds_zone_walk(res, domain):
         lambda h, hc, dc: "0.{0}".format(h),
 
         # Append a hyphen to the host portion
-        lambda h, hc, dc: "{0}-.{1}".format(hc, dc),
+        lambda h, hc, dc: "{0}-.{1}".format(hc, dc) if hc else None,
 
         # Double the last character of the host portion
-        lambda h, hc, dc: "{0}{1}.{2}".format(hc, hc[-1], dc)
+        lambda h, hc, dc: "{0}{1}.{2}".format(hc, hc[-1], dc) if hc else None
     ]
 
     pending = set([domain])
@@ -1271,12 +1271,25 @@ def ds_zone_walk(res, domain):
             records.extend(lookup_next(hostname, res))
 
             # Arrange the arguments for the transformations
-            fields = re.search("(^[^.]*).(\S*)", hostname)
-            params = [hostname, fields.group(1), fields.group(2)]
+            fields = re.search("^(^[^.]*)\.(\S+\.\S*)$", hostname)
+
+            if fields and fields.group(2):
+                domain_portion = fields.group(2)
+            else:
+                domain_portion = hostname
+
+            if fields and fields.group(1):
+                host_portion = fields.group(1)
+            else:
+                host_portion = ""
+
+            params = [hostname, host_portion, domain_portion]
 
             for transformation in transformations:
                 # Apply the transformation
                 target = transformation(*params)
+                if not target:
+                    continue
 
                 # Perform a DNS query for the target and process the response
                 if not nameserver:
@@ -1305,6 +1318,9 @@ def ds_zone_walk(res, domain):
         print_error("sure you can reach the target DNS Servers directly and requests")
         print_error("are not being filtered. Increase the timeout to a higher number")
         print_error("with --lifetime <time> option.")
+
+    except (EOFError):
+        print_error("SoA nameserver {} failed to answer the DNSSEC query for {}".format(nameserver, target))
 
     except (socket.error):
         print_error("SoA nameserver {} failed to answer the DNSSEC query for {}".format(nameserver, domain))

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1273,15 +1273,13 @@ def ds_zone_walk(res, domain):
             # Arrange the arguments for the transformations
             fields = re.search("^(^[^.]*)\.(\S+\.\S*)$", hostname)
 
+            domain_portion = hostname
             if fields and fields.group(2):
                 domain_portion = fields.group(2)
-            else:
-                domain_portion = hostname
 
+            host_portion = ""
             if fields and fields.group(1):
                 host_portion = fields.group(1)
-            else:
-                host_portion = ""
 
             params = [hostname, host_portion, domain_portion]
 

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1283,6 +1283,9 @@ def ds_zone_walk(res, domain):
 
             params = [hostname, host_portion, domain_portion]
 
+            walk_filter = "." + domain_portion
+            walk_filter_offset = len(walk_filter) + 1
+
             for transformation in transformations:
                 # Apply the transformation
                 target = transformation(*params)
@@ -1303,7 +1306,10 @@ def ds_zone_walk(res, domain):
                     #   2) The subsequent existing hostname that is signed
                     # Add the latter to our list of pending hostnames
                     for r in a:
-                        pending.add(r.next.to_text()[:-1])
+                        # Avoid walking outside of the target domain. This
+                        # happens with certain misconfigured domains.
+                        if r.next.to_text()[-walk_filter_offset:-1] == walk_filter:
+                            pending.add(r.next.to_text()[:-1])
 
             # Ensure nothing pending has already been queried
             pending -= finished


### PR DESCRIPTION
This PR does two things:

- handles an `EOFError` exception that is raised by the `dns` package in certain circumstances. This was due to the mutation of the hostname in `ds_zone_walk` that is caused when walking certain domains and mutating the domain name. For example: `vgt.at` -> `vgt-.at`. 

```shell
[*] Performing NSEC Zone Walk for vgt.at
[*] Getting SOA record for vgt.at
[*] Name Server 184.172.157.218 will be used
[*]      A vgt.at 92.43.96.132
Traceback (most recent call last):
  File "/home/UserHere/git/dnsrecon/dnsrecon.py", line 1704, in <module>
    main()
  File "/home/UserHere/git/dnsrecon/dnsrecon.py", line 1617, in main
    returned_records.extend(ds_zone_walk(res, domain))
  File "/home/UserHere/git/dnsrecon/dnsrecon.py", line 1285, in ds_zone_walk
    response = get_a_answer(res, target, nameserver, timeout)
  File "/home/UserHere/git/dnsrecon/dnsrecon.py", line 1209, in get_a_answer
    answer = res.query(query, ns, timeout)
  File "/home/UserHere/git/dnsrecon/lib/dnshelper.py", line 80, in query
    return dns.query.tcp(q, where, timeout, port, af, source, source_port, one_rr_per_rrset)
  File "/home/UserHere/.local/lib/python2.7/site-packages/dns/query.py", line 491, in tcp
    q.keyring, q.mac, ignore_trailing)
  File "/home/UserHere/.local/lib/python2.7/site-packages/dns/query.py", line 419, in receive_tcp
    ldata = _net_read(sock, 2, expiration)
  File "/home/UserHere/.local/lib/python2.7/site-packages/dns/query.py", line 349, in _net_read
    raise EOFError
EOFError

```
- Second, as seen above, the transformation logic will cause the logic to begin to walk domains that are not related to the intended target.  This happens in the transform that adds a trailing dash (`-`) between the hostname and the domain name (`pop.google.com` -> `pop-.google.com`) as well as the transform that doubles the next to last character in the hostname portion (`pop.google.com` -> `popp.google.com`).  The root of this issue is that the regex can split the provided hostname at unexpected places. 

Original regex - `(^[^.]*).(\S*)` (see live at - https://regex101.com/r/gqia6f/2)

|hostname     | group 1 / host | group2 / domain |
|:------------|--------:|:---------|
|www.google.com|www|google.com|
|trustedtraders.which.co.uk|trustedtraders|which.co.uk|
|which.co.uk|which|co.uk|
|co.uk|co|uk|
|google.com|google|com|
|registro.br|registro|br|
|br|b|r|

For the last 5 examples above the code ends up domain walking unrelated domains. In the case of `registro.br` this results in a transformation to `registroo.br` which ends up walking `.br` which appears to have NSEC widely enabled. This is noisy, delays the result, and is not, I think, the intent behind the code.

The new regex splits on the first period and requires that the remaining text contain a period with text around it.

New regex - `^(^[^.]*)\.(\S+\.\S*)$` (see live at - https://regex101.com/r/K0zWOF/3)

|hostname     | group 1 / host | group2 / domain |
|:------------|--------:|:---------|
|www.google.com|www|google.com|
|trustedtraders.which.co.uk|trustedtraders|which.co.uk|
|which.co.uk|which|co.uk|
|co.uk|||
|google.com| | |
|registro.br| | |
|br| | |


In the code, anything that doesn't generate a match to the regex is treated as the domain portion (formerly `fields.group(2)`) and the hostname portion (formerly `fields.group(1)`) is set to an empty string. Logic is then added to the lambda function to ensure that the code handles this missing value correctly.


Note: Splitting and dealing with country codes remains a bit iffy. I looked at using the `tld` package to filter them out but when handling `co.uk` is still split that into two parts. So the solution isn't perfect, but it should be much better.

### Testing
The changes were tested with Python 2 and 3.

Test before and after to see if the code starts walking the root `.br` domain. Currently in the `master` branch it will start working on `.br` after about 5 lookups.

```
python3 ./dnsrecon.py -t zonewalk -d registro.br
```
 
Test before and after to see if the code dies to an `EOFError` exception when walking `vgt.at`.
```
python3 ./dnsrecon.py -t zonewalk -d vgt.at
```

