### PR TITLE
Add args to disable checks

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1368,7 +1368,7 @@ def usage():
     print("   --xml             <file>     XML file to save found records.")
     print("   --iw                         Continue brute forcing a domain even if a wildcard records are discovered.")
     print("   --disable_check_recursion    Disables check for recursion on name servers.")
-    print("   --disable_check_bindversion  Disables check for Bind version on name servers.")
+    print("   --disable_check_bindversion  Disables check for BIND version on name servers.")
     print("   -c, --csv         <file>     Comma separated value file.")
     print("   -j, --json        <file>     JSON file.")
     print("   -v                           Show attempts in the brute force modes.")
@@ -1439,7 +1439,7 @@ def main():
         parser.add_argument("-j", "--json", type=str, dest="json", help="JSON file.")
         parser.add_argument("--iw", help="Continue brute forcing a domain even if a wildcard records are discovered.", action="store_true")
         parser.add_argument("--disable_check_recursion", help="Disables check for recursion on name servers", action="store_true")
-        parser.add_argument("--disable_check_bindversion", help="Disables check for Bind version on name servers", action="store_true")
+        parser.add_argument("--disable_check_bindversion", help="Disables check for BIND version on name servers", action="store_true")
         parser.add_argument("-v", help="Enable verbose", action="store_true")
         arguments = parser.parse_args()
 

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -74,6 +74,10 @@ from lib.msf_print import *
 # Global Variables for Brute force Threads
 brtdata = []
 
+CONFIG = {
+    "disable_check_recursion": False,
+    "disable_check_bindversion": False
+}
 
 # Function Definitions
 # -------------------------------------------------------------------------------
@@ -873,14 +877,17 @@ def check_bindversion(res, ns_server, timeout):
     Check if the version of Bind can be queried for.
     """
     version = ""
-    request = dns.message.make_query('version.bind', 'txt', 'ch')
-    try:
-        response = res.query(request, ns_server, timeout=timeout, one_rr_per_rrset=True)
-        if (len(response.answer) > 0):
-            print_status("\t Bind Version for {0} {1}".format(ns_server, response.answer[0].items[0].strings[0]))
-            version = response.answer[0].items[0].strings[0]
-    except (dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoAnswer, socket.error, dns.query.BadResponse):
-        return version
+
+    if not CONFIG or not CONFIG.get("disable_check_bindversion", False):
+        request = dns.message.make_query('version.bind', 'txt', 'ch')
+        try:
+            response = res.query(request, ns_server, timeout=timeout, one_rr_per_rrset=True)
+            if (len(response.answer) > 0):
+                print_status("\t Bind Version for {0} {1}".format(ns_server, response.answer[0].items[0].strings[0]))
+                version = response.answer[0].items[0].strings[0]
+        except (dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoAnswer, socket.error, dns.query.BadResponse):
+            pass
+
     return version
 
 
@@ -889,17 +896,20 @@ def check_recursive(res, ns_server, timeout):
     Check if a NS Server is recursive.
     """
     is_recursive = False
-    query = dns.message.make_query('www.google.com.', dns.rdatatype.NS)
-    try:
-        response = res.query(query, ns_server, timeout)
-        recursion_flag_pattern = "\.*RA\.*"
-        flags = dns.flags.to_text(response.flags)
-        result = re.findall(recursion_flag_pattern, flags)
-        if (result):
-            print_error("\t Recursion enabled on NS Server {0}".format(ns_server))
-        is_recursive = True
-    except (socket.error, dns.exception.Timeout):
-        return is_recursive
+
+    if not CONFIG or not CONFIG.get("disable_check_recursion", False):
+        query = dns.message.make_query('www.google.com.', dns.rdatatype.NS)
+        try:
+            response = res.query(query, ns_server, timeout)
+            recursion_flag_pattern = "\.*RA\.*"
+            flags = dns.flags.to_text(response.flags)
+            result = re.findall(recursion_flag_pattern, flags)
+            if (result):
+                print_error("\t Recursion enabled on NS Server {0}".format(ns_server))
+            is_recursive = True
+        except (socket.error, dns.exception.Timeout):
+            pass
+
     return is_recursive
 
 
@@ -1357,6 +1367,8 @@ def usage():
     print("   --db              <file>     SQLite 3 file to save found records.")
     print("   --xml             <file>     XML file to save found records.")
     print("   --iw                         Continue brute forcing a domain even if a wildcard records are discovered.")
+    print("   --disable_check_recursion    Disables check for recursion on name servers.")
+    print("   --disable_check_bindversion  Disables check for Bind version on name servers.")
     print("   -c, --csv         <file>     Comma separated value file.")
     print("   -j, --json        <file>     JSON file.")
     print("   -v                           Show attempts in the brute force modes.")
@@ -1426,6 +1438,8 @@ def main():
         parser.add_argument("-c", "--csv", type=str, dest="csv", help="Comma separated value file.")
         parser.add_argument("-j", "--json", type=str, dest="json", help="JSON file.")
         parser.add_argument("--iw", help="Continue brute forcing a domain even if a wildcard records are discovered.", action="store_true")
+        parser.add_argument("--disable_check_recursion", help="Disables check for recursion on name servers", action="store_true")
+        parser.add_argument("--disable_check_bindversion", help="Disables check for Bind version on name servers", action="store_true")
         parser.add_argument("-v", help="Enable verbose", action="store_true")
         arguments = parser.parse_args()
 
@@ -1488,6 +1502,8 @@ def main():
     json_file = arguments.json
     verbose = arguments.v
     ignore_wildcardrr = arguments.iw
+    CONFIG['disable_check_recursion'] = arguments.disable_check_recursion
+    CONFIG['disable_check_bindversion'] = arguments.disable_check_bindversion
 
     xfr = arguments.a
     goo = arguments.g


### PR DESCRIPTION
This PR adds command line options to disable BIND version and recursion checks. The goal is to speed up the process (if you don't need this data) and to reduce the number of requests made.

New options:
`--disable_check_recursion`
`--disable_check_bindversion`

Note that the above uses underscores for consistency with existing code (`--name_server`).

In the case of disabling recursion checks the tests against `qq.com` shown in the Testing section complete roughly a minute faster with the checks disabled. This test was performed with the check disabled first so that if anything benefited from caching it would be the original behavior. 

The flags for disabling the checks were implemented in a new global variable named `CONFIG`. I know that globals are often unpopular but I made the choice in this case to avoid adding function/method arguments through multiple levels of the call stack.  This change be changed if desired.

### Testing

#### BIND version check

Normal
```shell
$ python2 ./dnsrecon.py -t std -d dynect.net
[*] Performing General Enumeration of Domain:dynect.net
[-] DNSSEC is not configured for dynect.net
[*] 	 SOA ns0.dynamicnetworkservices.net 208.78.68.100
[*] 	 NS ns1.dynamicnetworkservices.net 208.78.70.136
[*] 	 Bind Version for 208.78.70.136 9.10.5-P3.
[*] 	 NS ns1.dynamicnetworkservices.net 2001:500:90:1::136
[*] 	 Bind Version for 2001:500:90:1::136 9.10.5-P3.
[*] 	 NS ns4.dynamicnetworkservices.net 204.13.251.136
[*] 	 Bind Version for 204.13.251.136 9.10.5-P3.
[*] 	 NS ns3.dynamicnetworkservices.net 208.78.71.136
[*] 	 Bind Version for 208.78.71.136 9.10.5-P3.
[*] 	 NS ns3.dynamicnetworkservices.net 2001:500:94:1::136
[*] 	 Bind Version for 2001:500:94:1::136 9.10.5-P3.
[*] 	 NS ns7.dynamicnetworkservices.net 108.59.165.1
[*] 	 Bind Version for 108.59.165.1 Vertex
[*] 	 NS ns7.dynamicnetworkservices.net 2a02:e180:8::1
[*] 	 Bind Version for 2a02:e180:8::1 Vertex
[*] 	 NS ns2.dynamicnetworkservices.net 204.13.250.136
[*] 	 Bind Version for 204.13.250.136 9.10.5-P3.
[*] 	 NS ns6.dynamicnetworkservices.net 162.88.61.21
[*] 	 Bind Version for 162.88.61.21 PowerDNS Authoritative Server 3.4.11 (jenkins@autotest.powerdns.com built 20170113105955 root@autotest.powerdns.com)
[*] 	 NS ns6.dynamicnetworkservices.net 2600:2000:1001::21
[*] 	 Bind Version for 2600:2000:1001::21 PowerDNS Authoritative Server 3.4.11 (jenkins@autotest.powerdns.com built 20170113105955 root@autotest.powerdns.com)
[*] 	 NS ns5.dynamicnetworkservices.net 162.88.60.21
[*] 	 Bind Version for 162.88.60.21 PowerDNS Authoritative Server 3.4.11 (jenkins@autotest.powerdns.com built 20170113105955 root@autotest.powerdns.com)
[*] 	 NS ns5.dynamicnetworkservices.net 2600:2000:1000::21
[*] 	 Bind Version for 2600:2000:1000::21 PowerDNS Authoritative Server 3.4.11 (jenkins@autotest.powerdns.com built 20170113105955 root@autotest.powerdns.com)
[*] 	 MX mail.dyndns.com 216.146.45.10
[*] 	 MX a410204.mx.mailhop.org 54.68.193.51
[*] 	 MX mail2.dyndns.com 216.146.45.10
[*] 	 A dynect.net 162.88.175.94
[*] 	 AAAA dynect.net 2600:2003:1200:1000::7
[*] 	 TXT dynect.net google-site-verification=WVUjgkIgDyXrFC6ud6KR80tmy0Lf_TgJsJsuL7diu_U
[*] 	 TXT dynect.net google-site-verification=UWOMnxGqpaaCg1rpNQJG-AKIShqnzI3gSKhmlYi-kOE
[*] 	 TXT dynect.net google-site-verification=F15UWeCm0v9vlDmCwOY330lsK0O3l1z-FH2CSXuwRTE
[*] 	 TXT dynect.net google-site-verification=sgBRexTbfwTDVOiqcQADQ7seuU70n6LCwvCPPMOa6jg
[*] 	 TXT dynect.net google-site-verification=QFGIv2ZBwE0780Ms6l_C1jsJOvGgFZSESR1IeTGPUl8
[*] 	 TXT dynect.net v=spf1 include:spf.dynect.net include:spf6.dynect.net include:sendlabs.com include:_spf.salesforce.com a:zgateway.zuora.com ~all
[*] 	 TXT _domainkey.dynect.net  t=y; o=~;
[*] Enumerating SRV Records
[-] No SRV Records Found for dynect.net
[+] 0 Records Found
```

Disable BIND version check

```shell
$ $ python2 ./dnsrecon.py -t std -d dynect.net --disable_check_bindversion
*] Performing General Enumeration of Domain:dynect.net
[-] DNSSEC is not configured for dynect.net
[*] 	 SOA ns0.dynamicnetworkservices.net 208.78.68.100
[*] 	 NS ns1.dynamicnetworkservices.net 208.78.70.136
[*] 	 NS ns1.dynamicnetworkservices.net 2001:500:90:1::136
[*] 	 NS ns4.dynamicnetworkservices.net 204.13.251.136
[*] 	 NS ns3.dynamicnetworkservices.net 208.78.71.136
[*] 	 NS ns3.dynamicnetworkservices.net 2001:500:94:1::136
[*] 	 NS ns7.dynamicnetworkservices.net 108.59.165.1
[*] 	 NS ns7.dynamicnetworkservices.net 2a02:e180:8::1
[*] 	 NS ns2.dynamicnetworkservices.net 204.13.250.136
[*] 	 NS ns6.dynamicnetworkservices.net 162.88.61.21
[*] 	 NS ns6.dynamicnetworkservices.net 2600:2000:1001::21
[*] 	 NS ns5.dynamicnetworkservices.net 162.88.60.21
[*] 	 NS ns5.dynamicnetworkservices.net 2600:2000:1000::21
[*] 	 MX a410204.mx.mailhop.org 54.191.214.36
[*] 	 MX mail.dyndns.com 216.146.45.10
[*] 	 MX mail2.dyndns.com 216.146.45.10
[*] 	 A dynect.net 162.88.175.94
[*] 	 AAAA dynect.net 2600:2003:1200:1000::7
[*] 	 TXT dynect.net google-site-verification=WVUjgkIgDyXrFC6ud6KR80tmy0Lf_TgJsJsuL7diu_U
[*] 	 TXT dynect.net v=spf1 include:spf.dynect.net include:spf6.dynect.net include:sendlabs.com include:_spf.salesforce.com a:zgateway.zuora.com ~all
[*] 	 TXT dynect.net google-site-verification=UWOMnxGqpaaCg1rpNQJG-AKIShqnzI3gSKhmlYi-kOE
[*] 	 TXT dynect.net google-site-verification=F15UWeCm0v9vlDmCwOY330lsK0O3l1z-FH2CSXuwRTE
[*] 	 TXT dynect.net google-site-verification=sgBRexTbfwTDVOiqcQADQ7seuU70n6LCwvCPPMOa6jg
[*] 	 TXT dynect.net google-site-verification=QFGIv2ZBwE0780Ms6l_C1jsJOvGgFZSESR1IeTGPUl8
[*] 	 TXT _domainkey.dynect.net  t=y; o=~;
[*] Enumerating SRV Records
[-] No SRV Records Found for dynect.net
[+] 0 Records Found
```


#### Recursion check

Normal

```shell
$ python2 ./dnsrecon.py -t std -d qq.com
[*] Performing General Enumeration of Domain:qq.com
[-] DNSSEC is not configured for qq.com
[*] 	 SOA ns1.qq.com 183.3.226.207
[*] 	 SOA ns1.qq.com 157.255.246.101
[*] 	 SOA ns1.qq.com 101.89.19.165
[*] 	 NS ns1.qq.com 101.89.19.165
[-] 	 Recursion enabled on NS Server 101.89.19.165
[*] 	 NS ns1.qq.com 183.3.226.207
[*] 	 NS ns1.qq.com 157.255.246.101
[*] 	 NS ns2.qq.com 203.205.177.41
[*] 	 NS ns2.qq.com 123.151.66.78
[-] 	 Recursion enabled on NS Server 123.151.66.78
[*] 	 NS ns2.qq.com 121.51.160.100
[-] 	 Recursion enabled on NS Server 121.51.160.100
[*] 	 NS ns3.qq.com 183.192.201.116
[-] 	 Recursion enabled on NS Server 183.192.201.116
[*] 	 NS ns3.qq.com 112.60.1.69
[-] 	 Recursion enabled on NS Server 112.60.1.69
[*] 	 NS ns4.qq.com 184.105.206.124
[*] 	 NS ns4.qq.com 58.144.154.100
[*] 	 NS ns4.qq.com 125.39.46.125
[-] 	 Recursion enabled on NS Server 125.39.46.125
[*] 	 NS ns4.qq.com 203.205.221.79
[*] 	 MX mx3.qq.com 103.7.30.40
[*] 	 MX mx2.qq.com 157.255.174.11
[*] 	 MX mx1.qq.com 203.205.219.58
[*] 	 MX mx1.qq.com 203.205.219.57
[*] 	 MX mx3.qq.com 2001:df6:f400::2808
[*] 	 MX mx2.qq.com 2001:df6:f400::2808
[*] 	 MX mx1.qq.com 2001:df6:f400::2808
[*] 	 A qq.com 111.161.64.40
[*] 	 A qq.com 111.161.64.48
[*] 	 TXT qq.com v=spf1 include:spf.mail.qq.com -all
[*] Enumerating SRV Records
[*] 	 SRV _caldavs._tcp.qq.com dav.qq.com 220.249.243.199 443 5
[*] 	 SRV _caldavs._tcp.qq.com dav.qq.com 157.255.174.114 443 5
[*] 	 SRV _carddavs._tcp.qq.com dav.qq.com 157.255.174.114 443 5
[*] 	 SRV _carddavs._tcp.qq.com dav.qq.com 220.249.243.199 443 5
[*] 	 SRV _caldav._tcp.qq.com dav.qq.com 157.255.174.114 80 5
[*] 	 SRV _caldav._tcp.qq.com dav.qq.com 220.249.243.199 80 5
[*] 	 SRV _carddav._tcp.qq.com dav.qq.com 157.255.174.114 80 5
[*] 	 SRV _carddav._tcp.qq.com dav.qq.com 220.249.243.199 80 5
[+] 8 Records Found
```

Disable recursion check

```shell
$ python2 ./dnsrecon.py -t std -d qq.com --disable_check_recursion
[*] Performing General Enumeration of Domain:qq.com
[-] DNSSEC is not configured for qq.com
[*] 	 SOA ns1.qq.com 157.255.246.101
[*] 	 SOA ns1.qq.com 101.89.19.165
[*] 	 SOA ns1.qq.com 183.3.226.207
[*] 	 NS ns2.qq.com 203.205.177.41
[*] 	 NS ns2.qq.com 123.151.66.78
[*] 	 NS ns2.qq.com 121.51.160.100
[*] 	 NS ns3.qq.com 112.60.1.69
[*] 	 NS ns3.qq.com 183.192.201.116
[*] 	 NS ns4.qq.com 203.205.221.79
[*] 	 NS ns4.qq.com 184.105.206.124
[*] 	 NS ns4.qq.com 58.144.154.100
[*] 	 NS ns4.qq.com 125.39.46.125
[*] 	 NS ns1.qq.com 157.255.246.101
[*] 	 NS ns1.qq.com 101.89.19.165
[*] 	 NS ns1.qq.com 183.3.226.207
[*] 	 MX mx3.qq.com 103.7.30.40
[*] 	 MX mx2.qq.com 157.255.174.11
[*] 	 MX mx1.qq.com 203.205.219.57
[*] 	 MX mx1.qq.com 203.205.219.58
[*] 	 MX mx3.qq.com 2001:df6:f400::2808
[*] 	 MX mx2.qq.com 2001:df6:f400::2808
[*] 	 MX mx1.qq.com 2001:df6:f400::2808
[*] 	 A qq.com 111.161.64.48
[*] 	 A qq.com 111.161.64.40
[*] 	 TXT qq.com v=spf1 include:spf.mail.qq.com -all
[*] Enumerating SRV Records
[*] 	 SRV _carddav._tcp.qq.com dav.qq.com 157.255.174.114 80 5
[*] 	 SRV _carddav._tcp.qq.com dav.qq.com 220.249.243.199 80 5
[*] 	 SRV _caldav._tcp.qq.com dav.qq.com 157.255.174.114 80 5
[*] 	 SRV _caldav._tcp.qq.com dav.qq.com 220.249.243.199 80 5
[*] 	 SRV _caldavs._tcp.qq.com dav.qq.com 220.249.243.199 443 5
[*] 	 SRV _caldavs._tcp.qq.com dav.qq.com 157.255.174.114 443 5
[*] 	 SRV _carddavs._tcp.qq.com dav.qq.com 220.249.243.199 443 5
[*] 	 SRV _carddavs._tcp.qq.com dav.qq.com 157.255.174.114 443 5
[+] 8 Records Found
```