### PR TITLE
Support multiple resolvers

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1326,6 +1326,7 @@ def usage():
     print("   -d, --domain      <domain>   Target domain.")
     print("   -r, --range       <range>    IP range for reverse lookup brute force in formats (first-last) or in (range/bitmask).")
     print("   -n, --name_server <name>     Domain server to use. If none is given, the SOA of the target will be used.")
+    print("                                Multiple servers can be specified using a comma separated list.")
     print("   -D, --dictionary  <file>     Dictionary file of subdomain and hostnames to use for brute force.")
     print("   -f                           Filter out of brute force domain lookup, records that resolve to the wildcard defined")
     print("                                IP address when saving records.")
@@ -1406,7 +1407,7 @@ def main():
     parser = argparse.ArgumentParser()
     try:
         parser.add_argument("-d", "--domain", type=str, dest="domain", help="Target domain.")
-        parser.add_argument("-n", "--name_server",type=str, dest="ns_server", help="Domain server to use. If none is given,    the SOA of the target will be used.")
+        parser.add_argument("-n", "--name_server",type=str, dest="ns_server", help="Domain server to use. If none is given,    the SOA of the target will be used. Multiple servers can be specified using a comma separated list.")
         parser.add_argument("-r", "--range",type=str, dest="range", help="IP range for reverse lookup brute force in formats   (first-last) or in (range/bitmask).")
         parser.add_argument("-D", "--dictionary",type=str, dest="dictionary", help="Dictionary file of subdomain and hostnames to use for brute force. Filter out of brute force domain lookup, records that resolve to the wildcard defined IP address when saving records.")
         parser.add_argument("-f", help="Filter out of brute force domain lookup, records that resolve to the wildcard defined IP address when saving records.", action="store_true")


### PR DESCRIPTION
This PR adds basic support for using multiple resolvers. They can be specified by passing a comma separated list to the `-n` or `--name_server` arguments. This does not change existing behavior if one name server is provided.

`./dnsrecon.py -n 8.8.8.8,1.1.1.1 $target_domain`

Code where specific name servers are used, for example using SoA when performing domain walking, should not be impacted.

**NOTE**: This change does not implement load balancing or any form of fair distribution of load across the servers. It simply rotates the order that the list is consumed by using `random.shuffle`.

### Background
The `Resolver` object in the `dnspython` library accepts a `list` of nameservers. When performing lookups it will make a request to the first entry in the list and will move to the next server if the previous lookup failed.  It can be configured to rotate through the list when making initial connections.  It doesn't have a process for load balancing the requests, it just performs a `random.shuffle` on the list which is better than nothing.

### Testing

Use Wireshark or `tcpdump` to observe the traffic generated by the following commands. For the multi server commands you should see traffic being sent to all of the specified servers.

#### Using multiple servers

With a functional IPv6 stack
```
./dnsrecon.py -n 8.8.8.8,8.8.4.4,1.1.1.1,1.1.0.0,2001:4860:4860::8888,2606:4700:4700::1111,2620:fe::fe --threads 30  -t std,srv -d $target_domain
```

Without a functional IPv6 stack
```
./dnsrecon.py -n 8.8.8.8,8.8.4.4,1.1.1.1,1.1.0.0 --threads 30  -t std,srv -d $target_domain
```

#### Using a single server

With a functional IPv6 stack
```
./dnsrecon.py -n 2001:4860:4860::8888 --threads 30  -t std,srv -d $target_domain
```

Without a functional IPv6 stack
```
./dnsrecon.py -n 8.8.8.8 --threads 30  -t std,srv -d $target_domain
```
