### PR TITLE
Handle invalid SoA

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -950,7 +950,6 @@ def general_enum(res, domain, do_axfr, do_google, do_bing, do_spf, do_whois, do_
         dns_sec_check(domain, res)
 
         # Enumerate SOA Record
-        found_soa_records = res.get_soa()
         try:
             found_soa_records = res.get_soa()
             for found_soa_record in found_soa_records:
@@ -1248,7 +1247,7 @@ def ds_zone_walk(res, domain):
         res = DnsHelper(domain, soa_rcd, 3)
         nameserver = soa_rcd
     except:
-        print_error("This zone appears to be miss configured, no SOA record found.")
+        print_error("This zone appears to be misconfigured, no SOA record found.")
 
     timeout = res._res.timeout
 


### PR DESCRIPTION
This PR addresses an exception that is raised when an SoA record doesn't exist or (depending on the DNS server `dnsrecon` is using) points to an A record that doesn't exist. The exception is due to the SoA lookup being performed twice (likely just a copy-paste error) with the first lookup being outside of the try/except block. The fix removes the unnecessary first lookup.

Exception
```
[*] Performing General Enumeration of Domain:office.de
[-] DNSSEC is not configured for office.de
Traceback (most recent call last):
  File "./dnsrecon.py", line 1748, in <module>
    main()
  File "./dnsrecon.py", line 1579, in main
    std_enum_records = general_enum(res, domain, xfr, goo, bing, spf_enum, do_whois, do_crt, zonewalk)
  File "./dnsrecon.py", line 953, in general_enum
    found_soa_records = res.get_soa()
  File "/Users/username/git/dnsrecon/lib/dnshelper.py", line 236, in get_soa
    ipv4_answers = self._res.query(name, 'A', tcp=tcp)
  File "/usr/local/lib/python2.7/site-packages/dns/resolver.py", line 898, in query
    raise NoNameservers(request=request, errors=errors)
dns.resolver.NoNameservers: All nameservers failed to answer the query lexpr01dc0008.deuprd01.prod.outlook.de. IN A: Server 8.8.8.8 UDP port 53 answered SERVFAIL
```

### Testing
This can be tested using `office.de` which has an SoA record that points to `lexpr01dc0008.deuprd01.prod.outlook.de` which doesn't exist.  I've attempted to notify Microsoft of this.

`./dnsrecon.py -n 8.8.8.8 -v -t std -d office.de`
