### PR TITLE
Add check for NXDOMAIN Hijacking

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -306,7 +306,7 @@ def check_nxdomain_hijack(nameserver):
 
     if len(address) > 0:
         print_error("Nameserver {} performs NXDOMAIN hijacking".format(nameserver))
-        print_error("It resolves non-existant domains to {}".format(", ".join(address)))
+        print_error("It resolves nonexistent domains to {}".format(", ".join(address)))
         print_error("This server has been removed from the name server list!")
         return True
 

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -273,6 +273,45 @@ def check_wildcard(res, domain_trg):
 
     return wildcard
 
+def check_nxdomain_hijack(nameserver):
+    """
+    Function for checking if a name server performs NXDOMAIN hijacking
+    """
+
+    test_name = ''.join(Random().sample(string.hexdigits + string.digits,
+                                        20)) + ".com"
+
+    res = dns.resolver.Resolver(configure=False)
+    res.nameservers = [nameserver]
+    res.timeout = 5.0
+
+    address = []
+
+    for record_type in ('A', 'AAAA'):
+        try:
+            answers = res.query(test_name, record_type, tcp=True)
+        except (dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoAnswer, socket.error, dns.query.BadResponse):
+            continue
+
+        if answers:
+            for ardata in answers.response.answer:
+                for rdata in ardata:
+                    if rdata.rdtype == 5:
+                        if rdata.target.to_text().endswith('.'):
+                            address.append(rdata.target.to_text()[:-1])
+                        else:
+                            address.append(rdata.target.to_text())
+                    else:
+                        address.append(rdata.address)
+
+    if len(address) > 0:
+        print_error("Nameserver {} performs NXDOMAIN hijacking".format(nameserver))
+        print_error("It resolves non-existant domains to {}".format(", ".join(address)))
+        print_error("This server has been removed from the name server list!")
+        return True
+
+    return False
+
 
 def brute_tlds(res, domain, verbose=False):
     """
@@ -1481,6 +1520,8 @@ def main():
         ns_server = []
         ns_raw_list = list(set(arguments.ns_server.split(",")))
         for entry in ns_raw_list:
+            if check_nxdomain_hijack(entry):
+                continue
             if netaddr.valid_glob(entry):
                 ns_server.append(entry)
             else:


### PR DESCRIPTION
This PR adds detection of name servers which perform NXDOMAIN Hijacking and will remove any that do this from the list the code uses.

### Context
Certain ISPs will hijack NXDOMAIN responses for nonexistent domains and point them to IP addresses they control for advertising purposes. Malicious DNS servers could do the same.  The result is that invalid results are returned from `dnsrecon.py`.

**NOTE**: In this writeup I'm using Level3's `4.2.2.2` DNS server which appears to hijack nonexistent domains **AND**  subdomains of real domains that don't resolve and that match certain patterns.


#### Example of DNS hijacking

The domain `705dB13f8940Cc4586e9.com` doesn't exist but Level3's name servers (`4.2.2.2`) seem to think that it does.

```
dig @4.2.2.2 A 705dB13f8940Cc4586e9.com

; <<>> DiG 9.10.6 <<>> @4.2.2.2 A 705dB13f8940Cc4586e9.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 6987
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;705dB13f8940Cc4586e9.com.	IN	A

;; ANSWER SECTION:
705dB13f8940Cc4586e9.com. 10	IN	A	104.239.213.7
705dB13f8940Cc4586e9.com. 10	IN	A	198.105.244.11

;; Query time: 64 msec
;; SERVER: 4.2.2.2#53(4.2.2.2)
;; WHEN: Mon Apr 08 08:53:20 CDT 2019
;; MSG SIZE  rcvd: 74
```

Here is the proper `NXDOMAIN` response:
```
dig @8.8.8.8 A 705dB13f8940Cc4586e9.com

; <<>> DiG 9.10.6 <<>> @8.8.8.8 A 705dB13f8940Cc4586e9.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 8624
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;705dB13f8940Cc4586e9.com.	IN	A

;; AUTHORITY SECTION:
com.			899	IN	SOA	a.gtld-servers.net. nstld.verisign-grs.com. 1554731649 1800 900 604800 86400

;; Query time: 57 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Mon Apr 08 08:54:24 CDT 2019
;; MSG SIZE  rcvd: 126
```

Here it is hijacking `ww2.microsoft.com`

```
 dig @4.2.2.2 A ww2.microsoft.com

; <<>> DiG 9.10.6 <<>> @4.2.2.2 A ww2.microsoft.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 9387
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;ww2.microsoft.com.		IN	A

;; ANSWER SECTION:
ww2.microsoft.com.	10	IN	A	104.239.213.7
ww2.microsoft.com.	10	IN	A	198.105.244.11

;; Query time: 55 msec
;; SERVER: 4.2.2.2#53(4.2.2.2)
;; WHEN: Mon Apr 08 09:54:33 CDT 2019
;; MSG SIZE  rcvd: 67
```

Correct response

```
dig @8.8.8.8 A ww2.microsoft.com

; <<>> DiG 9.10.6 <<>> @8.8.8.8 A ww2.microsoft.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 32288
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;ww2.microsoft.com.		IN	A

;; AUTHORITY SECTION:
microsoft.com.		1799	IN	SOA	ns1.msft.net. msnhst.microsoft.com. 2019040603 7200 600 2419200 3600

;; Query time: 54 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Mon Apr 08 09:55:50 CDT 2019
;; MSG SIZE  rcvd: 101
```



#### `dnsrecon` output comparison

Level3 DNS appears to lie about certain records and not others.

For the examples below, here is the `brute_list.txt` file that was used.
```
admin
autoconfig
autodiscover
cpanel
home
mail
mailserver
mysql
webmail
whm
wiki
wordpress
wp
ww1
www
www1
www2
```

Results against `4.2.2.2` without changes in this PR. Entries that resolve to `104.239.213.7` and `198.105.244.11` are fake.

```
[*] Performing host and subdomain brute force against lamarihuana.com
[*] 	 A mysql.lamarihuana.com 104.239.213.7
[*] 	 A mysql.lamarihuana.com 198.105.244.11
[*] 	 A home.lamarihuana.com 104.239.213.7
[*] 	 A home.lamarihuana.com 198.105.244.11
[*] 	 CNAME mail.lamarihuana.com mailsrv9.dondominio.com
[*] 	 A mailsrv9.dondominio.com 31.214.176.10
[*] 	 A webmail.lamarihuana.com 104.239.213.7
[*] 	 A webmail.lamarihuana.com 198.105.244.11
[*] 	 A whm.lamarihuana.com 104.239.213.7
[*] 	 A whm.lamarihuana.com 198.105.244.11
[*] 	 A wiki.lamarihuana.com 104.239.213.7
[*] 	 A wiki.lamarihuana.com 198.105.244.11
[*] 	 A wordpress.lamarihuana.com 104.239.213.7
[*] 	 A wordpress.lamarihuana.com 198.105.244.11
[*] 	 A wp.lamarihuana.com 91.134.186.24
[*] 	 CNAME www.lamarihuana.com lamarihuana.com
[*] 	 A lamarihuana.com 91.134.186.24
[*] 	 A ww1.lamarihuana.com 104.239.213.7
[*] 	 A ww1.lamarihuana.com 198.105.244.11
[*] 	 A www1.lamarihuana.com 104.239.213.7
[*] 	 A www1.lamarihuana.com 198.105.244.11
[*] 	 A www2.lamarihuana.com 104.239.213.7
[*] 	 A www2.lamarihuana.com 198.105.244.11
[+] 23 Records Found
```

Results against `8.8.8.8` without changes in this PR:
```
[*] Performing host and subdomain brute force against lamarihuana.com
[*] 	 A wp.lamarihuana.com 91.134.186.24
[*] 	 CNAME www.lamarihuana.com lamarihuana.com
[*] 	 A lamarihuana.com 91.134.186.24
[*] 	 CNAME mail.lamarihuana.com mailsrv9.dondominio.com
[*] 	 A mailsrv9.dondominio.com 31.214.176.10
[+] 5 Records Found
```

Verifying that `ww1.lamarihuana.com` doesn't actually have a record (`NXDOMAIN`):
```
dig @8.8.8.8 A ww1.lamarihuana.com

; <<>> DiG 9.10.6 <<>> @8.8.8.8 A ww1.lamarihuana.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 11863
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;ww1.lamarihuana.com.		IN	A

;; AUTHORITY SECTION:
lamarihuana.com.	179	IN	SOA	ns0.dnsmadeeasy.com. dns.dnsmadeeasy.com. 2008010305 43200 3600 1209600 180

;; Query time: 58 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Mon Apr 08 09:47:15 CDT 2019
;; MSG SIZE  rcvd: 104
```



Resolving a nonexistent domain **with** the changes in this PR against **Level3**:
```
./dnsrecon.py -D brute_list.txt -t brt -d lamarihuana.com -n 4.2.2.2
Testing 4.2.2.2 with 91A904bF3D7e3d60147C.com
[-] Nameserver 4.2.2.2 performs NXDOMAIN hijacking
[-] It resolves nonexistent domains to 104.239.213.7, 198.105.244.11
[-] This server has been removed from the name server list!
[-] Please specify valid name servers.
```

Against **Google**:
```
./dnsrecon.py -D brute_list.txt -t brt -d lamarihuana.com -n 8.8.8.8
[*] Performing host and subdomain brute force against lamarihuana.com
[*] 	 A wp.lamarihuana.com 91.134.186.24
[*] 	 CNAME www.lamarihuana.com lamarihuana.com
[*] 	 A lamarihuana.com 91.134.186.24
[*] 	 CNAME mail.lamarihuana.com mailsrv9.dondominio.com
[*] 	 A mailsrv9.dondominio.com 31.214.176.10
[+] 5 Records Found
```

And using them **both**:
```
  ./dnsrecon.py -D brute_list.txt -t brt -d lamarihuana.com -n 8.8.8.8,4.2.2.2
[-] Nameserver 4.2.2.2 performs NXDOMAIN hijacking
[-] It resolves nonexistent domains to 104.239.213.7, 198.105.244.11
[-] This server has been removed from the name server list!
[*] Performing host and subdomain brute force against lamarihuana.com
[*] 	 A wp.lamarihuana.com 91.134.186.24
[*] 	 CNAME mail.lamarihuana.com mailsrv9.dondominio.com
[*] 	 A mailsrv9.dondominio.com 31.214.176.10
[*] 	 CNAME www.lamarihuana.com lamarihuana.com
[*] 	 A lamarihuana.com 91.134.186.24
[+] 5 Records Found
```