### PR TITLE
Typo in derived class attribute for urllib.request.FancyURLopener

### DIFF
--- a/lib/gooenum.py
+++ b/lib/gooenum.py
@@ -31,7 +31,7 @@ except AttributeError:
 
 class AppURLopener(url_opener):
   
-    sudo  = "Mozilla/5.0 (compatible; Googlebot/2.1; + http://www.google.com/bot.html)"
+    version  = "Mozilla/5.0 (compatible; Googlebot/2.1; + http://www.google.com/bot.html)"
 
 
 def scrape_google(dom):


### PR DESCRIPTION
"sudo" isn't an attribute of the base class. "version" is a commonly overwritten attribute.