### PR TITLE
With Python 3 the HTTP 429 is not properly process.

### DIFF
--- a/lib/gooenum.py
+++ b/lib/gooenum.py
@@ -54,9 +54,14 @@ def scrape_google(dom):
             sock = urllib.urlopen(url)
             data = sock.read()
         except AttributeError:
-            request=urllib.request.Request(url,None,headers)
-            sock = urllib.request.urlopen(request)
-            data = sock.read().decode("utf-8") 
+            try:
+                request=urllib.request.Request(url,None,headers)
+                sock = urllib.request.urlopen(request)
+                data = sock.read().decode("utf-8") 
+
+            except urllib.error.HTTPError:
+                print_error("Google has return an HTTP error and detected the search as \'bot activity, stopping search...")
+                return results
 
         if re.search('Our systems have detected unusual traffic from your computer network',data) != None:
             print_error("Google has detected the search as \'bot activity, stopping search...")


### PR DESCRIPTION
Here is the backtrace I had before that this change solve:

[*] Performing Google Search Enumeration
Traceback (most recent call last):
  File "dnsrecon/lib/gooenum.py", line 54, in scrape_google
    sock = urllib.urlopen(url)
AttributeError: module 'urllib' has no attribute 'urlopen'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "dnsrecon.py", line 1788, in <module>
    main()
  File "dnsrecon.py", line 1746, in main
    std_enum_records = general_enum(res, domain, xfr, goo, bing, spf_enum, do_whois, do_crt, zonewalk)
  File "dnsrecon.py", line 1101, in general_enum
    goo_rcd = se_result_process(res, scrape_google(domain))
  File "/dnsrecon/lib/gooenum.py", line 58, in scrape_google
    sock = urllib.request.urlopen(request)
  File "/usr/lib/python3.5/urllib/request.py", line 163, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.5/urllib/request.py", line 472, in open
    response = meth(req, response)
  File "/usr/lib/python3.5/urllib/request.py", line 582, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.5/urllib/request.py", line 504, in error
    result = self._call_chain(*args)
  File "/usr/lib/python3.5/urllib/request.py", line 444, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.5/urllib/request.py", line 696, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/lib/python3.5/urllib/request.py", line 472, in open
    response = meth(req, response)
  File "/usr/lib/python3.5/urllib/request.py", line 582, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.5/urllib/request.py", line 510, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.5/urllib/request.py", line 444, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.5/urllib/request.py", line 590, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 429: Too Many Requests