### PR TITLE
Fix check_nxdomain_hijack raises uncaught NoNameservers

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -290,7 +290,7 @@ def check_nxdomain_hijack(nameserver):
     for record_type in ('A', 'AAAA'):
         try:
             answers = res.query(test_name, record_type, tcp=True)
-        except (dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoAnswer, socket.error, dns.query.BadResponse):
+        except (dns.resolver.NoNameservers, dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoAnswer, socket.error, dns.query.BadResponse):
             continue
 
         if answers:


### PR DESCRIPTION
Fixes case when DNS ignores check for nxdomain hijack.
-----
Traceback (most recent call last):         
  File "./dnsrecon.py", line 1788, in <module>
    main()                                     
  File "./dnsrecon.py", line 1522, in main
    if check_nxdomain_hijack(entry):     
  File "./dnsrecon.py", line 292, in check_nxdomain_hijack
    answers = res.query(test_name, record_type, tcp=True)
  File "/usr/lib/python2.7/dist-packages/dns/resolver.py", line 898, in query
    raise NoNameservers(request=request, errors=errors)
dns.resolver.NoNameservers: All nameservers failed to answer the query 8A9bB533f860E7d9a401.com.