### PR TITLE
Avoid exception on srv record list handling

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -358,7 +358,7 @@ def brute_srv(res, domain, verbose=False, thread_num=None):
     if len(brtdata) > 0:
         for rcd_found in brtdata:
             for rcd in rcd_found:
-                returned_records.append([{"type": rcd[0],
+                returned_records.extend([{"type": rcd[0],
                                          "name": rcd[1],
                                          "target": rcd[2],
                                          "address": rcd[3],


### PR DESCRIPTION
When a domain has more than one SRV record we get the following exception:
```
Traceback (most recent call last):
  File "./dnsrecon.py", line 1759, in <module>
    main()
  File "./dnsrecon.py", line 1578, in main
    thread_num=thread_num)
  File "./dnsrecon.py", line 1030, in general_enum
    ip_for_whois.append(r["address"])
TypeError: list indices must be integers or slices, not str
```
It appears to be a bug in the list handling (append instead of extend) on function brute_srv()