### PR TITLE
Handle Cloudflare's NSEC tweak

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1200,8 +1200,8 @@ def get_next(res, target, ns, timeout):
 
 def ds_zone_walk(res, domain):
     """
-    Perform DNSSEC Zone Walk using NSEC records found the the error additional
-    records section of the message to find the next host to query int he zone.
+    Perform DNSSEC Zone Walk using NSEC records found in the error additional
+    records section of the message to find the next host to query in the zone.
     """
     print_status("Performing NSEC Zone Walk for {0}".format(domain))
 
@@ -1284,6 +1284,14 @@ def ds_zone_walk(res, domain):
                     #   2) The subsequent existing hostname that is signed
                     # Add the latter to our list of pending hostnames
                     for r in a:
+
+                        # As an optimization Cloudflare (and perhaps others)
+                        # return '\000.' instead of NODATA when a record doesn't
+                        # exist. Detect this and avoid becoming tarpitted while
+                        # permuting the namespace.
+                        if r.next.to_text()[:5] =='\\000.':
+                            continue
+
                         # Avoid walking outside of the target domain. This
                         # happens with certain misconfigured domains.
                         if r.next.to_text()[-walk_filter_offset:-1] == walk_filter:


### PR DESCRIPTION
This PR handle's Cloudflare's tweak to NSEC that prevent's zonewalking while also reducing the size of the response. You can read the full context here:

https://blog.cloudflare.com/black-lies/

### Testing

The changes were tested with the following command line
```bash
./dnsrecon.py -n 8.8.4.4 -t zonewalk -d domain_name_here
```

**Domains in this section have the issue**

`foxsports.com` - Has the issue - Before
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d foxsports.com
[*] Performing NSEC Zone Walk for foxsports.com
[*] Getting SOA record for foxsports.com
[*] Name Server 198.51.44.6 will be used
[*] 	 A foxsports.com 23.11.216.240
[*] 	 A \000.0.foxsports.com no_ip
[*] 	 A \000.\000.0.foxsports.com no_ip
[*] 	 A \000.0.\000.0.foxsports.com no_ip
[*] 	 A \000.\0000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000-.\000.0.foxsports.com no_ip
[*] 	 A \000.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.\0000.0.foxsports.com no_ip
[*] 	 A \000.\000.\0000.0.foxsports.com no_ip
[*] 	 A \000.\000-.\0000.\000.0.foxsports.com no_ip
[*] 	 A \000.\0000.0.\000.0.foxsports.com no_ip
[*] 	 A \000.0.\000.\000.\0000.0.foxsports.com no_ip
[*] 	 A \000.0.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000-.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000.\000-.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000-.\000.\000-.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000-.\000.\0000.0.foxsports.com no_ip
[*] 	 A \000.\000-.0.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000-.\0000.0.foxsports.com no_ip
[*] 	 A \000.0.\000.\0000.0.foxsports.com no_ip
[*] 	 A \000.\0000.\0000.0.\000.0.foxsports.com no_ip
[*] 	 A \000.\000.\0000.\000.0.foxsports.com no_ip
[*] 	 A \000.\0000.\000.\000-.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000.\000.\000-.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.0.\000.\000.\0000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000.\000-.\000.0.foxsports.com no_ip
[*] 	 A \000.0.\000.\000-.\0000.\000.0.foxsports.com no_ip
[*] 	 A \000.\0000.\000-.\000.\000-.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.0.\000.\0000.\0000.0.\000.0.foxsports.com no_ip
[*] 	 A \000.0.\000.0.\000.\000.\0000.0.foxsports.com no_ip
[*] 	 A \000.\000-.\0000.\000-.\000.\000-.\000.\000.0.foxsports.com no_ip
[*] 	 A \000.\000.\000.\000-.\000.0.foxsports.com no_ip
<snip_as_this_continues_for_quite_some_time>
```

`foxsports.com` - After
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d foxsports.com
[*] Performing NSEC Zone Walk for foxsports.com
[*] Getting SOA record for foxsports.com
[*] Name Server 198.51.44.6 will be used
[*] 	 A foxsports.com 23.11.216.240
[+] 1 records found
```

`foxnews.com` and `foxbusiness.com` have the same issue.


`time.com` - Before
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d time.com
[*] Performing NSEC Zone Walk for time.com
[*] Getting SOA record for time.com
[*] Name Server 198.51.44.8 will be used
[*] 	 A time.com 13.249.71.17
[*] 	 A time.com 13.249.71.49
[*] 	 A time.com 13.249.71.124
[*] 	 A time.com 13.249.71.15
[*] 	 A \000.0.time.com no_ip
[*] 	 A \000.\0000.0.time.com no_ip
[*] 	 A \000.0.\000.\0000.0.time.com no_ip
[*] 	 A \000.0.\000.0.time.com no_ip
[*] 	 A \000.0.\000.0.\000.0.time.com no_ip
[*] 	 A \000.\000-.\0000.0.time.com no_ip
[*] 	 A \000.0.\000.0.\000.\0000.0.time.com no_ip
[*] 	 A \000.0.\000.0.\000.0.\000.\0000.0.time.com no_ip
[*] 	 A \000.\000-.\000-.\0000.0.time.com no_ip
[*] 	 A \000.\0000.0.\000.0.\000.\0000.0.time.com no_ip
[*] 	 A \000.\0000.0.\000.0.\000.0.\000.\0000.0.time.com no_ip
[*] 	 A \000.\000-.\000-.\000-.\0000.0.time.com no_ip
[*] 	 A \000.0.\000.\0000.0.\000.0.\000.0.\000.\0000.0.time.com no_ip
[*] 	 A \000.\000.\000-.\000-.\000-.\0000.0.time.com no_ip
^C[-] You have pressed Ctrl + C. Saving found records.
```

`time.com` - After
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d time.com
[*] Performing NSEC Zone Walk for time.com
[*] Getting SOA record for time.com
[*] Name Server 198.51.44.8 will be used
[*] 	 A time.com 13.249.71.124
[*] 	 A time.com 13.249.71.15
[*] 	 A time.com 13.249.71.17
[*] 	 A time.com 13.249.71.49
[+] 4 records found
```


`cloudflare.com` - Minor issue - Before
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d cloudflare.com
[*] Performing NSEC Zone Walk for cloudflare.com
[*] Getting SOA record for cloudflare.com
[*] Name Server 162.159.7.226 will be used
[*] 	 AAAA cloudflare.com 2606:4700::6811:b055
[*] 	 AAAA cloudflare.com 2606:4700::6811:af55
[*] 	 A cloudflare.com 104.17.176.85
[*] 	 A cloudflare.com 104.17.175.85
[*] 	 A \000.0.cloudflare.com no_ip
[+] 5 records found
```

`cloudflare.com` - After
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d cloudflare.com
[*] Performing NSEC Zone Walk for cloudflare.com
[*] Getting SOA record for cloudflare.com
[*] Name Server 162.159.7.226 will be used
[*] 	 AAAA cloudflare.com 2606:4700::6811:b055
[*] 	 AAAA cloudflare.com 2606:4700::6811:af55
[*] 	 A cloudflare.com 104.17.176.85
[*] 	 A cloudflare.com 104.17.175.85
[+] 4 records found
```
**Domains here don't have the issue, they are here to show no change**

`ietf.org` - After
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d ietf.org
[*] Performing NSEC Zone Walk for ietf.org
[*] Getting SOA record for ietf.org
[*] Name Server 4.31.198.40 will be used
[*] 	 AAAA ietf.org 2001:1900:3001:11::2c
[*] 	 A ietf.org 4.31.198.44
[*] 	 A _dmarc.ietf.org no_ip
[*] 	 A ietf1._domainkey.ietf.org no_ip
[+] 4 records found
```
`ietf.org` - After
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d ietf.org
[*] Performing NSEC Zone Walk for ietf.org
[*] Getting SOA record for ietf.org
[*] Name Server 4.31.198.40 will be used
[*] 	 AAAA ietf.org 2001:1900:3001:11::2c
[*] 	 A ietf.org 4.31.198.44
[*] 	 A _dmarc.ietf.org no_ip
[*] 	 A ietf1._domainkey.ietf.org no_ip
[+] 4 records found
```

`a.bg` - Before
```bash
 ~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d a.bg
[*] Performing NSEC Zone Walk for a.bg
[*] Getting SOA record for a.bg
[*] Name Server 192.92.129.99 will be used
[*] 	 A a.bg no_ip
[*] 	 A digsys.a.bg no_ip
[*] 	 A dnssec.a.bg no_ip
[*] 	 A sra.a.bg no_ip
[*] 	 A studio.a.bg 160.153.129.232
[*] 	 A xn--80ab4aksg.a.bg no_ip
[+] 6 records found
```

`a.bg` - After
```bash
~/git/dnsrecon/dnsrecon.py -n 8.8.4.4 -t zonewalk -d a.bg
[*] Performing NSEC Zone Walk for a.bg
[*] Getting SOA record for a.bg
[*] Name Server 192.92.129.99 will be used
[*] 	 A a.bg no_ip
[*] 	 A digsys.a.bg no_ip
[*] 	 A dnssec.a.bg no_ip
[*] 	 A sra.a.bg no_ip
[*] 	 A studio.a.bg 160.153.129.232
[*] 	 A xn--80ab4aksg.a.bg no_ip
[+] 6 records found

```

