### PR TITLE
Zone Transfer Fix

### DIFF
--- a/lib/dnshelper.py
+++ b/lib/dnshelper.py
@@ -373,7 +373,10 @@ class DnsHelper:
                                            rrset.covers, True)
                 zrds.update_ttl(rrset.ttl)
                 for rd in rrset:
-                    rd.choose_relativity(z.origin, relativize)
+                    try:
+                        rd.choose_relativity(z.origin, relativize)
+                    except AttributeError:
+                        pass
                     zrds.add(rd)
 
         return z


### PR DESCRIPTION
Hi,

While running `python3 dnsrecon.py -d zonetransfer.me -t axfr --json test.json` the following error is thrown:

```
root@kali:~/dnsrecon# python3 dnsrecon.py -d zonetransfer.me -t axfr --json test.json
[*] Testing NS Servers for Zone Transfer
[*] Checking for Zone Transfer for zonetransfer.me name servers
[*] Resolving SOA Record
['SOA', 'nsztm1.digi.ninja', '81.4.108.41']
[+] 	 SOA nsztm1.digi.ninja 81.4.108.41
[*] Resolving NS Records
[*] NS Servers found:
[*] 	NS nsztm2.digi.ninja 34.225.33.2
[*] 	NS nsztm1.digi.ninja 81.4.108.41
[*] Removing any duplicate NS server IP Addresses...
[*]
[*] Trying NS server 34.225.33.2
[+] [['NS', 'nsztm2.digi.ninja', '34.225.33.2'], ['NS', 'nsztm1.digi.ninja', '81.4.108.41']] Has port 53 TCP Open
[-] Zone Transfer Failed!
[-] 'SOA' object has no attribute 'choose_relativity'
Traceback (most recent call last):
  File "/root/dnsrecon/lib/dnshelper.py", line 428, in zone_transfer
    zone = self.from_wire(dns.query.xfr(ns_srv, self._domain))
  File "/root/dnsrecon/lib/dnshelper.py", line 376, in from_wire
    rd.choose_relativity(z.origin, relativize)
AttributeError: 'SOA' object has no attribute 'choose_relativity'
[*]
[*] Trying NS server 81.4.108.41
[+] [['NS', 'nsztm2.digi.ninja', '34.225.33.2'], ['NS', 'nsztm1.digi.ninja', '81.4.108.41']] Has port 53 TCP Open
[-] Zone Transfer Failed!
[-] 'SOA' object has no attribute 'choose_relativity'
Traceback (most recent call last):
  File "/root/dnsrecon/lib/dnshelper.py", line 428, in zone_transfer
    zone = self.from_wire(dns.query.xfr(ns_srv, self._domain))
  File "/root/dnsrecon/lib/dnshelper.py", line 376, in from_wire
    rd.choose_relativity(z.origin, relativize)
AttributeError: 'SOA' object has no attribute 'choose_relativity'
[*] Saving records to JSON file: test.json
```

This commit will fix this issue.

I do not know if this fix will negatively affect other parts of the code as I did not investigate any further. If it does, please discard this change.

Master branch (`git clone https://github.com/darkoperator/dnsrecon`) was tested with Python v3.8.5 on Kali Linux v2020.3 (64-bit).

Best regards,
Ivan.