### PR TITLE
bump dnspython version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dnspython
+dnspython>=2.0.0
 netaddr
 lxml
 flake8


### PR DESCRIPTION
Fixes issue https://github.com/darkoperator/dnsrecon/issues/146. 

Enforces a dnspython version of 2.0.0 or higher