### PR TITLE
little "optimization" when printing bind version

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -844,8 +844,9 @@ def check_bindversion(res, ns_server, timeout):
         try:
             response = res.query(request, ns_server, timeout=timeout, one_rr_per_rrset=True)
             if len(response.answer) > 0 and 'items' in response.answer[0]:
-                print_status(f"\t Bind Version for {ns_server} {response.answer[0].items[0].strings[0]}")
                 version = response.answer[0].items[0].strings[0]
+                print_status(f"\t Bind Version for {ns_server} {version}")
+                
         except (dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoAnswer, socket.error,
                 dns.query.BadResponse):
             pass


### PR DESCRIPTION
Swapped the two lines with the aim of reusing version in the print_status, instead of accessing twice response.answer[0].items[0].strings[0]