### PR TITLE
Enhancement to SQLite storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.orig
 *.pyc
 *.pyo
+venv/

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1708,4 +1708,4 @@ if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
-        print_status('CTRL+C detected, quiting')
+        print_status('CTRL+C detected, quitting')


### PR DESCRIPTION
Added a 'domain' column to the SQLite DB and created settings to save the queried domain to the DB alongside the DNS records. This allows you to keep a SQLite DB with all DNS queries returned for different dnsrecon runs. With this enhancement, you can query the DB with something like ```select * from data where domain = 'example.com';``` to get only the records from a specific scan.

This could easily be added to JSON and CSV but I didn't want to make too many changes at once.

[![asciicast](https://asciinema.org/a/390260.svg)](https://asciinema.org/a/390260)


