### PR TITLE
Fix missing "import re" in lib/dnshelper.py

### DIFF
--- a/lib/dnshelper.py
+++ b/lib/dnshelper.py
@@ -23,6 +23,7 @@ import dns.reversename
 import dns.message
 import socket
 import random
+import re
 from dns.zone import *
 from dns.dnssec import algorithm_to_text
 from .msf_print import *


### PR DESCRIPTION
Fix the following error on Ubuntu 20.04 / Python 3.8.5:

```
Traceback (most recent call last):
  File "./dnsrecon.py", line 1710, in <module>
    main()
  File "./dnsrecon.py", line 1669, in main
    std_enum_records = general_enum(res, domain, xfr, bing, yandex, spf_enum, do_whois, do_crt, zonewalk)
  File "./dnsrecon.py", line 944, in general_enum
    for ns_rcrd in res.get_ns():
  File "/home/me/github/dnsrecon/lib/dnshelper.py", line 201, in get_ns
    if re.search(r'^A', addresses[0]):
NameError: name 're' is not defined
```