### PR TITLE
lib: added error handling for dns.name.EmptyLabel to address issue #177

### DIFF
--- a/lib/dnshelper.py
+++ b/lib/dnshelper.py
@@ -82,7 +82,7 @@ class DnsHelper:
             return self._res.resolve(addr_, type_, tcp=self._is_tcp)
         except (dns.exception.Timeout, dns.resolver.NXDOMAIN,
                 dns.resolver.YXDOMAIN, dns.resolver.NoAnswer,
-                dns.resolver.NoNameservers, socket.error):
+                dns.resolver.NoNameservers, dns.name.EmptyLabel, socket.error):
             return None
 
     def resolve(self, target, type_, ns=None):


### PR DESCRIPTION
I added dns.name.EmptyLabel to the exception handling in lib/dnshelper.py at line 85 to resolve an issue I and some others were having.