### PR TITLE
Remove additional `--update` for apk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:alpine3.13
 WORKDIR /app
 COPY . /app
-RUN apk add --update --no-cache build-base libffi-dev libxml2-dev libxslt-dev
+RUN apk add --no-cache build-base libffi-dev libxml2-dev libxslt-dev
 RUN /usr/local/bin/python -m pip install --upgrade pip
 RUN /usr/local/bin/python --version
 RUN pip3 install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
There is no need to use `--update` with `--no-cache` when using `apk` on Alpine Linux, as using `--no-cache` will fetch the index every time and leave no local cache, so the index will always be the latest without temporary files remains in the image.