### PR TITLE
Fix in case of domain bruteforcing abortion

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1670,7 +1670,7 @@ Possible types:
                 brt_enum_records = brute_domain(res, dictionary, domain,
                                                 wildcard_filter, verbose, ignore_wildcardrr,
                                                 thread_num=thread_num)
-                if do_output:
+                if do_output and brt_enum_records:
                     returned_records.extend(brt_enum_records)
 
             elif type_ == 'srv':


### PR DESCRIPTION
If a user answer no when the program ask if they wish to continue after having found a wildcard during a brute force scan, the program raise the following error:

Traceback (most recent call last):
  File "/home/francesco_pavanello/Programmi/dnsrecon/dnsrecon.py", line 1764, in <module>
    main()
  File "/home/francesco_pavanello/Programmi/dnsrecon/dnsrecon.py", line 1674, in main
    returned_records.extend(brt_enum_records)
TypeError: 'NoneType' object is not iterable