### PR TITLE
[BUGFIX] SPF record types cause traceback while generating CSV output

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -721,7 +721,10 @@ def make_csv(data):
 
         elif type_ in ['TXT', 'SPF']:
             if 'zone_server' not in record:
-                csv_data += record['name']
+                if type_ == 'SPF':
+                    csv_data += record["domain"]
+                else:
+                    csv_data += record['name']
 
             csv_data += ("," * 4) + "'{}'\n".format(record['strings'])
 


### PR DESCRIPTION
## Summary

This PR addresses a traceback generated when emitting SPF records to CSV format.

**NOTE:** This involves the `SPF` DNS record type `99`, not a DNS `TXT` record containing a SPF directive. The `SPF` record type is relatively uncommon and was, AFAIK, never formally adopted. It has no impact on the SPF handling for a domain. 

[Per Wikipedia](https://en.wikipedia.org/wiki/List_of_DNS_record_types): 

> Support for it was discontinued in RFC 7208 due to widespread lack of support.

## Problem

When enumerating domains that contain a `SPF` record type (not a `TXT` spf record but the DNS type) the logic that generates the CSV output references a dictionary key that doesn't exist.

```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
    -n 8.8.8.8  -v -t std -f \
    -d techcrunch.com \
    -c delete_me.csv

[*] std: Performing General Enumeration against: techcrunch.com...
[-] DNSSEC is not configured for techcrunch.com
[*] 	 SOA ns1.techcrunch.com 192.16.16.5
[*] 	 SOA ns1.techcrunch.com 2606:2800:3::5
[*] 	 NS ns3.techcrunch.com 198.7.29.5
[*] 	 NS ns3.techcrunch.com 2606:2800:c::5
[*] 	 NS ns1.techcrunch.com 192.16.16.5
[*] 	 NS ns1.techcrunch.com 2606:2800:3::5
[*] 	 NS ns4.techcrunch.com 198.7.29.6
[*] 	 NS ns4.techcrunch.com 2606:2800:c::6
[*] 	 NS ns2.techcrunch.com 192.16.16.6
[*] 	 NS ns2.techcrunch.com 2606:2800:3::6
[*] 	 MX mxb-00505701.gslb.pphosted.com 148.163.139.55
[*] 	 MX mxa-00505701.gslb.pphosted.com 148.163.135.35
[*] 	 A techcrunch.com 76.13.32.141
[*] 	 A techcrunch.com 67.195.231.20
[*] 	 AAAA techcrunch.com 2001:4998:124:1704::5000
[*] 	 SPF >v=spf1 a mx include:_spf.google.com include:spf.protection.outlook.com include:u826348.wl.sendgrid.net -all
[*] 	 TXT techcrunch.com dropbox-domain-verification=sh3f8kienale
[*] 	 TXT techcrunch.com google-site-verification=DhlHJ_81bZLsrh5TLvK7ac04EG4QvEAa8hjtsiMpUTQ
[*] 	 TXT techcrunch.com docusign=1ad1e6cd-4dfe-4b34-8689-5797102f132e
[*] 	 TXT techcrunch.com google-site-verification=KsXJcvhk00hppwpZ3oNMk0GzB9M2GFUxA7XjdRVpc1U
[*] 	 TXT techcrunch.com v=spf1 a mx include:aspmx.sailthru.com include:_spf.google.com include:mktomail.com -all
[*] 	 TXT techcrunch.com google-site-verification=HgtRMjw2Jm4kQso_oGLMcQ7ndEv8wNcGa0Kquhm9KK0
[*] 	 TXT techcrunch.com zeplin
[*] 	 TXT techcrunch.com _globalsign-domain-verification=esDvs5Msz39F5o97VaHcZxyKR4A6NPHRpuo9du1Tro
[*] 	 TXT techcrunch.com google-site-verification=8tVHhkiXUNoPjI09EcLgjl9V7TwSXxLV0bnIjcEmpFw
[*] 	 TXT techcrunch.com 134052hpsyz5k73sv39m0sgxljsqyls7
[*] 	 TXT techcrunch.com knowbe4-site-verification=bc3830115833f4f956e30f506f1da8c8
[*] 	 TXT _dmarc.techcrunch.com v=DMARC1; p=none; fo=1; pct=100; rua=mailto:aol@rua.agari.com,mailto:rua@techcrunch.com; ruf=mailto:aol@ruf.agari.com,mailto:ruf@techcrunch.com
[*] Enumerating SRV Records
[+] 0 Records Found
[*] Saving records to CSV file: delete_me.csv
Traceback (most recent call last):
  File "/Users/me/git/dnsrecon/dnsrecon.py", line 1764, in <module>
    main()
  File "/Users/me/git/dnsrecon/dnsrecon.py", line 1752, in main
    write_to_file(make_csv(returned_records), csv_file)
  File "/Users/me/git/dnsrecon/dnsrecon.py", line 724, in make_csv
    csv_data += record['name']
KeyError: 'name'
```

The reason for the error is that the `name` key doesn't exist for the SPF record type.

```json
{"domain": "techcrunch.com", "type": "SPF", "strings": ">v=spf1 a mx include:_spf.google.com include:spf.protection.outlook.com include:u826348.wl.sendgrid.net -all"}
{"domain": "techcrunch.com", "type": "TXT", "name": "techcrunch.com", "strings": "docusign=1ad1e6cd-4dfe-4b34-8689-5797102f132e"}
```

This is despite `dnspython` basing the `SPF` record type on `TXT` which _does_ have the `name` field. This issue does **NOT** appear to impact writing output to JSON or to a database but I have not tested these scenarios.

After the attached change the code completes as expected.

```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
    -n 8.8.8.8  -v -t std -f \
    -d techcrunch.com \
    -c delete_me.csv

[*] std: Performing General Enumeration against: techcrunch.com...
[-] DNSSEC is not configured for techcrunch.com
[*] 	 SOA ns1.techcrunch.com 192.16.16.5
[*] 	 SOA ns1.techcrunch.com 2606:2800:3::5
[*] 	 NS ns4.techcrunch.com 198.7.29.6
[*] 	 NS ns4.techcrunch.com 2606:2800:c::6
[*] 	 NS ns3.techcrunch.com 198.7.29.5
[*] 	 NS ns3.techcrunch.com 2606:2800:c::5
[*] 	 NS ns1.techcrunch.com 192.16.16.5
[*] 	 NS ns1.techcrunch.com 2606:2800:3::5
[*] 	 NS ns2.techcrunch.com 192.16.16.6
[*] 	 NS ns2.techcrunch.com 2606:2800:3::6
[*] 	 MX mxb-00505701.gslb.pphosted.com 148.163.139.55
[*] 	 MX mxa-00505701.gslb.pphosted.com 148.163.135.35
[*] 	 A techcrunch.com 76.13.32.141
[*] 	 AAAA techcrunch.com 2001:4998:124:1704::5000
[*] 	 SPF >v=spf1 a mx include:_spf.google.com include:spf.protection.outlook.com include:u826348.wl.sendgrid.net -all
[*] 	 TXT techcrunch.com google-site-verification=HgtRMjw2Jm4kQso_oGLMcQ7ndEv8wNcGa0Kquhm9KK0
[*] 	 TXT techcrunch.com zeplin
[*] 	 TXT techcrunch.com google-site-verification=KsXJcvhk00hppwpZ3oNMk0GzB9M2GFUxA7XjdRVpc1U
[*] 	 TXT techcrunch.com google-site-verification=8tVHhkiXUNoPjI09EcLgjl9V7TwSXxLV0bnIjcEmpFw
[*] 	 TXT techcrunch.com _globalsign-domain-verification=esDvs5Msz39F5o97VaHcZxyKR4A6NPHRpuo9du1Tro
[*] 	 TXT techcrunch.com google-site-verification=DhlHJ_81bZLsrh5TLvK7ac04EG4QvEAa8hjtsiMpUTQ
[*] 	 TXT techcrunch.com v=spf1 a mx include:aspmx.sailthru.com include:_spf.google.com include:mktomail.com -all
[*] 	 TXT techcrunch.com 134052hpsyz5k73sv39m0sgxljsqyls7
[*] 	 TXT techcrunch.com docusign=1ad1e6cd-4dfe-4b34-8689-5797102f132e
[*] 	 TXT techcrunch.com knowbe4-site-verification=bc3830115833f4f956e30f506f1da8c8
[*] 	 TXT techcrunch.com dropbox-domain-verification=sh3f8kienale
[*] 	 TXT _dmarc.techcrunch.com v=DMARC1; p=none; fo=1; pct=100; rua=mailto:aol@rua.agari.com,mailto:rua@techcrunch.com; ruf=mailto:aol@ruf.agari.com,mailto:ruf@techcrunch.com
[*] Enumerating SRV Records
[+] 0 Records Found
[*] Saving records to CSV file: delete_me.csv
```

```shell
$ cat ./delete_me.csv 
Type,Name,Address,Target,Port,String
SOA,ns1.techcrunch.com,192.16.16.5,,,
SOA,ns1.techcrunch.com,2606:2800:3::5,,,
NS,ns4.techcrunch.com,198.7.29.6,,,
NS,ns4.techcrunch.com,2606:2800:c::6,,,
NS,ns3.techcrunch.com,198.7.29.5,,,
NS,ns3.techcrunch.com,2606:2800:c::5,,,
NS,ns1.techcrunch.com,192.16.16.5,,,
NS,ns1.techcrunch.com,2606:2800:3::5,,,
NS,ns2.techcrunch.com,192.16.16.6,,,
NS,ns2.techcrunch.com,2606:2800:3::6,,,
MX,mxb-00505701.gslb.pphosted.com,148.163.139.55,,,
MX,mxa-00505701.gslb.pphosted.com,148.163.135.35,,,
A,techcrunch.com,76.13.32.141,,,
AAAA,techcrunch.com,2001:4998:124:1704::5000,,,
SPF,techcrunch.com,,,,'>v=spf1 a mx include:_spf.google.com include:spf.protection.outlook.com include:u826348.wl.sendgrid.net -all'
TXT,techcrunch.com,,,,'google-site-verification=HgtRMjw2Jm4kQso_oGLMcQ7ndEv8wNcGa0Kquhm9KK0'
TXT,techcrunch.com,,,,'zeplin'
TXT,techcrunch.com,,,,'google-site-verification=KsXJcvhk00hppwpZ3oNMk0GzB9M2GFUxA7XjdRVpc1U'
TXT,techcrunch.com,,,,'google-site-verification=8tVHhkiXUNoPjI09EcLgjl9V7TwSXxLV0bnIjcEmpFw'
TXT,techcrunch.com,,,,'_globalsign-domain-verification=esDvs5Msz39F5o97VaHcZxyKR4A6NPHRpuo9du1Tro'
TXT,techcrunch.com,,,,'google-site-verification=DhlHJ_81bZLsrh5TLvK7ac04EG4QvEAa8hjtsiMpUTQ'
TXT,techcrunch.com,,,,'v=spf1 a mx include:aspmx.sailthru.com include:_spf.google.com include:mktomail.com -all'
TXT,techcrunch.com,,,,'134052hpsyz5k73sv39m0sgxljsqyls7'
TXT,techcrunch.com,,,,'docusign=1ad1e6cd-4dfe-4b34-8689-5797102f132e'
TXT,techcrunch.com,,,,'knowbe4-site-verification=bc3830115833f4f956e30f506f1da8c8'
TXT,techcrunch.com,,,,'dropbox-domain-verification=sh3f8kienale'
TXT,_dmarc.techcrunch.com,,,,'v=DMARC1; p=none; fo=1; pct=100; rua=mailto:aol@rua.agari.com,mailto:rua@techcrunch.com; ruf=mailto:aol@ruf.agari.com,mailto:ruf@techcrunch.com'
```