### PR TITLE
[BUGFIX] Zonewalk - improve exception handling

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1240,7 +1240,7 @@ def ds_zone_walk(res, domain, lifetime):
         soa_rcd = res.get_soa()[0][2]
 
         print_status(f'Name Server {soa_rcd} will be used')
-        res = DnsHelper(domain, [soa_rcd], lifetime)
+        res = DnsHelper(domain, soa_rcd, lifetime)
         nameserver = soa_rcd
 
         if nameserver == '':

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1240,10 +1240,14 @@ def ds_zone_walk(res, domain, lifetime):
         soa_rcd = res.get_soa()[0][2]
 
         print_status(f'Name Server {soa_rcd} will be used')
-        res = DnsHelper(domain, soa_rcd, lifetime)
+        res = DnsHelper(domain, [soa_rcd], lifetime)
         nameserver = soa_rcd
-    except Exception:
-        print_error("This zone appears to be misconfigured, no SOA record found.")
+
+        if nameserver == '':
+            print_error("This zone appears to be misconfigured, no SOA record found.")
+
+    except Exception as err:
+        print_error(f"Exception while trying to determine the SOA records for domain {domain}: {err}")
 
     timeout = res._res.timeout
 

--- a/lib/dnshelper.py
+++ b/lib/dnshelper.py
@@ -49,6 +49,8 @@ class DnsHelper:
         self._res = dns.resolver.Resolver(configure=configure)
 
         if ns_server:
+            if isinstance(ns_server, str):
+                ns_server = [ns_server]
             self._res.nameservers = ns_server
             if len(ns_server) > 1:
                 self._res.rotate = True


### PR DESCRIPTION
## Summary
This PR fixes an issue with zone walking caused by passing `dns.resolver.Resolver` a nameserver as a `str` instead of a `list`.   The logic continues but generates an incorrect error message (`This zone appears to be misconfigured, no SOA record found.`) and may use a different name server than that which was indicated.

### Output prior to code changes
```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
    -n 8.8.8.8  -v -t zonewalk -f \
    -d google.com

[*] Performing NSEC Zone Walk for google.com
[*] Getting SOA record for google.com
[*] Name Server 216.239.32.10 will be used
[-] This zone appears to be misconfigured, no SOA record found.
[*] 	 A google.com 142.251.32.206
[*] 	 AAAA google.com 2607:f8b0:4000:805::200e
[+] 2 records found
```


### Output after code changes
```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
    -n 8.8.8.8  -v -t zonewalk -f \
    -d google.com

[*] Performing NSEC Zone Walk for google.com
[*] Getting SOA record for google.com
[*] Name Server 216.239.32.10 will be used
[*] 	 A google.com 142.251.33.46
[*] 	 AAAA google.com 2607:f8b0:4000:818::200e
[+] 2 records found
```

## Problem
https://github.com/darkoperator/dnsrecon/blob/ddd3c7cdbe3cd0511ee573bc5037b68ff6050251/dnsrecon.py#L1240-L1246

On line 1240 we're getting the IP address of the first NS record. This is a `str`. 
The result from `get_soa()` looks something like this:
```json
[
    ['SOA', 'ns1.google.com', '216.239.32.10'],
    ['SOA', 'ns1.google.com', '2001:4860:4802:32::a']
]
```

That means that, in the case above, `soa_rcd` is a `str` containing `216.239.32.10`.

We then try to use this `str` as the name server value when creating a new `DnsHelper`.  

https://github.com/darkoperator/dnsrecon/blob/ddd3c7cdbe3cd0511ee573bc5037b68ff6050251/lib/dnshelper.py#L42-L52

During the `__init__` of a `DnsHelper` object the name server value (stored in `ns_server` is used to set the `nameserver` attribute which requires a `list`.  This then generates an `Exception`:

`nameservers must be a list (not a <class 'str'>)`

This was being masked in the existing code since a bare `except` is used in the `try` block.


The code then continues from there and if `nameserver` isn't set it uses the existing nameserver value from the current `res` object. This IP may be different that which was emitted on line 1242.

Changes made by the PR:
- Have the `except` block print out the actual `Exception` observed.
- Detect and print an error if we actually don't have a `SOA` IP
- Have the `__init__` method for `DnsHelper` automatically handle this use case so the problem is handled correctly globally.