### PR TITLE
[BUGFIX] SOA handling when SOA records don't exist.

### DIFF
--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1237,13 +1237,20 @@ def ds_zone_walk(res, domain, lifetime):
     nameserver = ''
 
     try:
-        soa_rcd = res.get_soa()[0][2]
+        # Get the list of SOA servers, should be a list of lists
+        target_soas = res.get_soa()
+        if target_soas:
+            first_ns = target_soas[0]
+            # The 3rd value is the SOA's IP address
+            if first_ns:
+                nameserver = first_ns[2]
 
-        print_status(f'Name Server {soa_rcd} will be used')
-        res = DnsHelper(domain, soa_rcd, lifetime)
-        nameserver = soa_rcd
+                if nameserver:
+                     # At this point we should have a name server IP in 'nameserver'
+                    print_status(f'Name Server {nameserver} will be used')
+                    res = DnsHelper(domain, nameserver, lifetime)
 
-        if nameserver == '':
+        if not nameserver:
             print_error("This zone appears to be misconfigured, no SOA record found.")
 
     except Exception as err:

--- a/dnsrecon.py
+++ b/dnsrecon.py
@@ -1246,7 +1246,7 @@ def ds_zone_walk(res, domain, lifetime):
                 nameserver = first_ns[2]
 
                 if nameserver:
-                     # At this point we should have a name server IP in 'nameserver'
+                    # At this point we should have a name server IP in 'nameserver'
                     print_status(f'Name Server {nameserver} will be used')
                     res = DnsHelper(domain, nameserver, lifetime)
 


### PR DESCRIPTION
## Summary

The error handling in PR #203 was incorrect and didn't properly handle zones without an `SOA`.

For example, in the cases below the `SOA` records don't exist.

### Before code changes
`list index out of range`
```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
    -n 8.8.8.8  -v -t zonewalk -f \
    -d com.akadns.net

[*] Performing NSEC Zone Walk for com.akadns.net
[*] Getting SOA record for com.akadns.net
[-] Exception while trying to determine the SOA records for domain com.akadns.net: list index out of range
[*] 	 A com.akadns.net no_ip
[+] 1 records found
```

```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
     -n 8.8.8.8  -v -t zonewalk -f \
     -d core.windows.net

[*] Performing NSEC Zone Walk for core.windows.net
[*] Getting SOA record for core.windows.net
[-] Exception while trying to determine the SOA records for domain core.windows.net: list index out of range
[*] 	 A core.windows.net no_ip
[+] 1 records found
```

### After code changes
```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
    -n 8.8.8.8  -v -t zonewalk -f \
    -d com.akadns.net

[*] Performing NSEC Zone Walk for com.akadns.net
[*] Getting SOA record for com.akadns.net
[-] This zone appears to be misconfigured, no SOA record found.
[*] 	 A com.akadns.net no_ip
[+] 1 records found
```

```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
     -n 8.8.8.8  -v -t zonewalk -f \
     -d core.windows.net

[*] Performing NSEC Zone Walk for core.windows.net
[*] Getting SOA record for core.windows.net
[-] This zone appears to be misconfigured, no SOA record found.
[*] 	 A core.windows.net no_ip
[+] 1 records found
```


### Against a domain with a valid `SOA`

```shell
$ ~/git/dnsrecon/dnsrecon.py --disable_check_recursion --disable_check_bindversion \
     -n 8.8.8.8  -v -t zonewalk -f \
     -d windows.net

*] Performing NSEC Zone Walk for windows.net
[*] Getting SOA record for windows.net
[*] Name Server 40.90.4.205 will be used
[*] 	 A windows.net 40.76.4.15
[*] 	 A windows.net 40.112.72.205
[*] 	 A windows.net 104.215.148.63
[*] 	 A windows.net 13.77.161.179
[*] 	 A windows.net 40.113.200.201
[+] 5 records found
```
