### PR TITLE
Ignoring error while decoding in utf-8

### DIFF
--- a/lib/dnshelper.py
+++ b/lib/dnshelper.py
@@ -267,7 +267,7 @@ class DnsHelper:
 
         result = []
         for answer in answers:
-            strings_ = bytes.join(b'', answer.strings).decode('utf-8')
+            strings_ = bytes.join(b'', answer.strings).decode('utf-8', errors='ignore')
             result.append(['SPF', strings_])
 
         return result
@@ -288,7 +288,7 @@ class DnsHelper:
                 continue
 
             for answer in answers:
-                strings_ = bytes.join(b'', answer.strings).decode('utf-8')
+                strings_ = bytes.join(b'', answer.strings).decode('utf-8', errors='ignore')
                 result.append(['TXT', target_, strings_])
 
         return result


### PR DESCRIPTION
python3 dnsrecon.py -d xxx.it -y -k -b -x xxx.it/dnsrecon_ykb_results.xml
[*] std: Performing General Enumeration against: xxx.it...
[-] DNSSEC is not configured for xxx.it
[*] 	 SOA ns1.xxx-net.it 195.78.215.242
[*] 	 NS ns1.xxx-net.it 195.78.215.242
[*] 	 NS ns2.xxx-net.it 195.78.223.242
[*] 	 MX et4.xxx.it 213.21.171.189
[*] 	 MX et3.xxx.it 213.21.171.188
[*] 	 A xxx.it 213.21.176.150
Traceback (most recent call last):
  File "dnsrecon.py", line 1780, in <module>
    main()
  File "dnsrecon.py", line 1667, in main
    std_enum_records = general_enum(res, domain, xfr, bing, yandex,
  File "dnsrecon.py", line 1019, in general_enum
    txt_text_data = res.get_txt()
  File "dnsrecon/lib/dnshelper.py", line 291, in get_txt
    strings_ = bytes.join(b'', answer.strings).decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x96 in position 216: invalid start byte