### PR TITLE
Bind Version was not being obtained as 'items' no longer exists in dn…

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -883,8 +883,8 @@ def check_bindversion(res, ns_server, timeout):
         request = dns.message.make_query('version.bind', 'txt', 'ch')
         try:
             response = res.query(request, ns_server, timeout=timeout, one_rr_per_rrset=True)
-            if len(response.answer) > 0 and 'items' in response.answer[0]:
-                version = response.answer[0].items[0].strings[0]
+            if len(response.answer) > 0:
+                version = response.answer[0].to_text().split(" ")[-1]
                 print_status(f"\t Bind Version for {ns_server} {version}")
 
         except (dns.resolver.NXDOMAIN, dns.exception.Timeout, dns.resolver.NoAnswer, socket.error,


### PR DESCRIPTION
The check_bindversion function wasn't returning the version even though it was contained in the response to ```request = dns.message.make_query('version.bind', 'txt', 'ch')```
The dns.rrset.RRset object returned by that query did not contain items and therefore would never evaluate to true, meaning the bind.version was ignored if it did exist.
This changes it by running the to_text() function of the RRset class and splitting it to get the last item which will should always be the version information.

Fixes #218 