### PR TITLE
Remove lgtm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
 # DNSRecon
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/darkoperator/dnsrecon.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/darkoperator/dnsrecon/context:python)
 
 DNSRecon is a Python port of a Ruby script that I wrote to learn the language and about DNS in early 2007. 
 This time I wanted to learn about Python and extend the functionality of the original tool and in the process re-learn how DNS works and how could it be used in the process of a security assessment and network troubleshooting. 


### PR DESCRIPTION
lgtm was acquired and shut down by GitHub, the badge doesn't work anymore.

https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/