### PR TITLE
[BUGFIX] Fixes missing A and AAAA records with brute force enumeration with -f

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -663,7 +663,7 @@ def brute_domain(res, dictfile, dom, filter_=None, verbose=False, ignore_wildcar
                     if type_ in ['A', 'AAAA']:
                         # Filter Records if filtering was enabled
                         if filter_:
-                            if wildcard_set and address_or_target_ not in wildcard_set:
+                            if not wildcard_set or address_or_target_ not in wildcard_set:
                                 print_and_append = True
                                 found_dict["address"] = address_or_target_
                         else:


### PR DESCRIPTION
**Feature Request or Bug or Other**
Bug

**Describe the feature request or bug or other**
When filtering to exclude records that resolve to the wildcard defined IP, if the domain does not actually have a wildcard record, no A or AAAA records will be reported.

**To Reproduce**
Steps to reproduce the behavior:
Using the following `dictionary.txt` file:
```
www
test
```
1. Run tool like this: `dnsrecon -t brt -d megacorpone.com --dictionary=dictionary.txt -f`
2. `dnsrecon` reports that no records were found:
```
$ dnsrecon -t brt -d megacorpone.com --dictionary=dictionary.txt -f
[*] Using the dictionary file: dictionary.txt (provided by user)
[*] brt: Performing host and subdomain brute force against megacorpone.com...
[+] 0 Records Found
```

**Corrected behavior**
magacorpone.com does not have a wildcard record so `dnsrecon` should report the same results with and without wildcard filtering.
```
$ dnsrecon -t brt -d megacorpone.com --dictionary=dictionary.txt -f
[*] Using the dictionary file: dictionary.txt (provided by user)
[*] brt: Performing host and subdomain brute force against megacorpone.com...
[+]      A test.megacorpone.com 51.222.169.219
[+]      A www.megacorpone.com 149.56.244.87
[+] 2 Records Found
```