### PR TITLE
Add dependencies to `setup.py`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
+[options]
+install_requires = file: requirements.txt
 [flake8]
 ignore = E501, F405, F403, E402

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,6 @@ setuptools.setup(
     url="https://github.com/darkoperator/dnsrecon",
     packages=setuptools.find_packages(exclude=["tests"]),
     python_requires='>=3.7',
-    install_requires=[
-        'dnspython>=2.0.0',
-        'netaddr',
-        'lxml',
-    ],
     entry_points={
         "console_scripts": [
             "dnsrecon = dnsrecon.__main__:main"

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ setuptools.setup(
     url="https://github.com/darkoperator/dnsrecon",
     packages=setuptools.find_packages(exclude=["tests"]),
     python_requires='>=3.7',
+    install_requires=[
+        'dnspython>=2.0.0',
+        'netaddr',
+        'lxml',
+    ],
     entry_points={
         "console_scripts": [
             "dnsrecon = dnsrecon.__main__:main"


### PR DESCRIPTION
Currently, when installing `dnsrecon` via

```
pip install 'dnsrecon @ git+https://github.com/darkoperator/dnsrecon@1.1.4'
```

Invocations of `dnsrecon` fail if the `lxml` package is not installed.

This PR updates `setup.py` to include `dnsrecon`'s required dependencies, in order to ensure it runs successfully when the command is installed in this fashion.