### PR TITLE
move run layer earlier to improve layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:alpine
+RUN apk add --no-cache build-base libffi-dev libxml2-dev libxslt-dev
 WORKDIR /app
 COPY . /app
-RUN apk add --no-cache build-base libffi-dev libxml2-dev libxslt-dev
 RUN /usr/local/bin/python -m pip install --upgrade pip
 RUN /usr/local/bin/python --version
 RUN pip3 install --no-cache-dir .


### PR DESCRIPTION
the current dockerfile organization means that any time any of the source code changes, we re-run the command to install the apk packages. Moving that line higher means that source code changes will not invalidate that layer, and we can build a bit faster.