### PR TITLE
fixed None Type is not iterable errors when type is list | None

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -1940,13 +1940,13 @@ Possible types:
             elif type_ == 'bing':
                 print_status(f'{type_}: Performing Bing Search Enumeration against {domain}...')
                 bing_enum_records = se_result_process(res, scrape_bing(domain))
-                if do_output:
+                if bing_enum_records is not None and do_output:
                     returned_records.extend(bing_enum_records)
 
             elif type_ == 'yand':
                 print_status(f'{type_}: Performing Yandex Search Enumeration against {domain}...')
                 yandex_enum_records = se_result_process(res, scrape_yandex(domain))
-                if do_output:
+                if yandex_enum_records is not None and do_output:
                     returned_records.extend(yandex_enum_records)
 
             elif type_ == 'crt':

--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -1952,8 +1952,10 @@ Possible types:
             elif type_ == 'crt':
                 print_status(f'{type_}: Performing Crt.sh Search Enumeration against {domain}...')
                 crt_enum_records = se_result_process(res, scrape_crtsh(domain))
-                if do_output:
+                if crt_enum_records is not None and do_output:
                     returned_records.extend(crt_enum_records)
+                else:
+                    print("[-] No records returned from crt.sh enumeration")
 
             elif type_ == 'snoop':
                 if not (dictionary and ns_server):

--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -1955,7 +1955,7 @@ Possible types:
                 if crt_enum_records is not None and do_output:
                     returned_records.extend(crt_enum_records)
                 else:
-                    print("[-] No records returned from crt.sh enumeration")
+                    print('[-] No records returned from crt.sh enumeration')
 
             elif type_ == 'snoop':
                 if not (dictionary and ns_server):


### PR DESCRIPTION
This resolves panics that occur from TypeError's when attempting to use the .extend method on None type objects.

```bash
[*] crt: Performing Crt.sh Search Enumeration against example.com...
[-] Bad http status from crt.sh: "503"
Traceback (most recent call last):
  File "/root/test/dnsrecon/bin/dnsrecon", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/root/test/dnsrecon/lib/python3.11/site-packages/dnsrecon/cli.py", line 1956, in main
    returned_records.extend(crt_enum_records)
TypeError: 'NoneType' object is not iterable
```