### PR TITLE
fixing IP not subscriptable and CIDR expansion issues

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -414,6 +414,7 @@ def brute_srv(res, domain, verbose=False, thread_num=None):
 
     return returned_records
 
+
 def brute_reverse(res, ip_list, verbose=False, thread_num=None):
     """
     Reverse look-up brute force for given CIDR example 192.168.1.1/24. Returns an
@@ -436,7 +437,7 @@ def brute_reverse(res, ip_list, verbose=False, thread_num=None):
     print_status(f'Performing Reverse Lookup from {start_ip} to {end_ip}')
 
     ip_group_size = 255
-    for ip_group in [expanded_ips[j: j + ip_group_size] for j in range(0, len(expanded_ips), ip_group_size)]:
+    for ip_group in [expanded_ips[j : j + ip_group_size] for j in range(0, len(expanded_ips), ip_group_size)]:
         try:
             if verbose:
                 for ip in ip_group:
@@ -456,13 +457,14 @@ def brute_reverse(res, ip_list, verbose=False, thread_num=None):
                                 returned_records.append({'type': type_, 'name': name_, 'address': addr_})
                                 print_good(f'\t {type_} {name_} {addr_}')
                     except Exception as e:
-                        print_error(f"Error resolving IP {ip_address}: {e}")
+                        print_error(f'Error resolving IP {ip_address}: {e}')
 
         except Exception as e:
-            print_error(f"Error with thread executor: {e}")
+            print_error(f'Error with thread executor: {e}')
 
     print_good(f'{len(returned_records)} Records Found')
     return returned_records
+
 
 def brute_domain(
     res,


### PR DESCRIPTION
Attempting to address two slightly related issues:

https://github.com/darkoperator/dnsrecon/issues/290
The change this is adjusting how `process_range()` handles the range expansion since calling the cli with `-r` uses `process_range()` to expand the user provided list before sending to `brute_reverse()`. 

and

https://github.com/darkoperator/dnsrecon/issues/287
The fix for this issue was just simplifying the handling of IP objects in `brute_reverse()` to be a bit more direct and reliable:
1. https://github.com/darkoperator/dnsrecon/compare/master...McFacePunch:dnsrecon:brute-crash-fix?expand=1#diff-fa039890da56f40e25e5f365886c5654c23d8901574fcef6b8e6330266bbe212R429
2. https://github.com/darkoperator/dnsrecon/compare/master...McFacePunch:dnsrecon:brute-crash-fix?expand=1#diff-fa039890da56f40e25e5f365886c5654c23d8901574fcef6b8e6330266bbe212R447

NOTE! I have not done extensive testing here. Less than 3 for each fix. More testing would be ideal.