### PR TITLE
Feature: Disable nxdomain hijacking check using flag.

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -1623,6 +1623,11 @@ def main():
             action='store_true',
         )
         parser.add_argument(
+        '--disable_check_nxdomain',
+        help='Disables check for NXDOMAIN hijacking on name servers.',
+        action='store_true'
+        )
+        parser.add_argument(
             '--disable_check_recursion',
             help='Disables check for recursion on name servers',
             action='store_true',
@@ -1781,8 +1786,9 @@ Possible types:
                 # Exit if we cannot resolve it
                 print_error(f"Could not resolve NS server provided and server doesn't appear to be an IP: {entry}")
 
-            if check_nxdomain_hijack(socket.gethostbyname(entry)):
-                continue
+            if not arguments.disable_check_nxdomain:
+                if check_nxdomain_hijack(socket.gethostbyname(entry)):
+                    continue
 
             if netaddr.valid_glob(entry):
                 ns_server.append(entry)

--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -1623,9 +1623,7 @@ def main():
             action='store_true',
         )
         parser.add_argument(
-        '--disable_check_nxdomain',
-        help='Disables check for NXDOMAIN hijacking on name servers.',
-        action='store_true'
+            '--disable_check_nxdomain', help='Disables check for NXDOMAIN hijacking on name servers.', action='store_true'
         )
         parser.add_argument(
             '--disable_check_recursion',


### PR DESCRIPTION
Allows you to disable NXDOMAIN hijacking by supplying `--disable_check_nxdomain` on the CLI.

Implements: https://github.com/darkoperator/dnsrecon/issues/109