### PR TITLE
Bug fix brute tld.

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -242,66 +242,57 @@ def check_nxdomain_hijack(nameserver):
 def brute_tlds(res, domain, verbose=False, thread_num=None):
     """
     This function performs a check of a given domain for known TLD values.
-    prints and returns a dictionary of the results.
+    Prints and returns a dictionary of the results.
     """
     global brtdata
     brtdata = []
 
-    # https://en.wikipedia.org/wiki/Country_code_top-level_domain#Types
-    # https://www.iana.org/domains
-    # Taken from http://data.iana.org/TLD/tlds-alpha-by-domain.txt
+    # Define TLDs and Country Code TLDs
     itld = ['arpa']
-
-    # Generic TLD
     gtld = TLDS.generic_tlds()
-
-    # Generic restricted TLD
     grtld = ['biz', 'name', 'pro']
-
-    # Sponsored TLD
     stld = TLDS.sponsored_tlds()
-
-    # Country Code TLD
     cctld = TLDS.country_codes()
 
     domain_main = domain.split('.')[0]
 
-    # Let the user know how long it could take
-    all_tlds_len = len(itld) + len(gtld) + len(grtld) + len(stld) + len(cctld)
-    duration = time.strftime('%H:%M:%S', time.gmtime(all_tlds_len / 3))
-    print_status(f'The operation could take up to: {duration}')
-
+    # Combine all TLDs
     total_tlds = list(set(itld + gtld + grtld + stld))
 
-    if verbose:
-        for tld in total_tlds:
-            print_status(f'Trying: {domain_main}.{tld}')
-        for cc in cctld:
-            print_status(f'Trying: {domain_main}.{cc}')
-        for cc, tld in zip(cctld, total_tlds):
-            print_status(f'Trying: {domain_main}.{cc}.{tld}')
+    # Let the user know how long it could take
+    total_combinations = len(cctld) * len(total_tlds)
+    duration = time.strftime('%H:%M:%S', time.gmtime(total_combinations / 3))
+    print_status(f'The operation could take up to: {duration}')
 
     found_tlds = []
+
     try:
         with futures.ThreadPoolExecutor(max_workers=thread_num) as executor:
-            future_results = {
-                **{executor.submit(res.get_ip, f'{domain_main}.{tld}'): tld for tld in total_tlds},
-                **{executor.submit(res.get_ip, f'{domain_main}.{cc}'): cc for cc in cctld},
-                **{executor.submit(res.get_ip, f'{domain_main}.{cc}.{tld}'): (cc, tld) for (cc, tld) in zip(cctld, total_tlds)},
-            }
+            future_results = {}
 
-            # Display logs as soon as a thread is finished
+            # Nested loop to combine cctld and total_tlds
+            for cc in cctld:
+                for tld in total_tlds:
+                    full_domain = f'{domain_main}.{cc}.{tld}'
+                    future_results[executor.submit(res.get_ip, full_domain)] = full_domain
+
+            # Display results as soon as threads are completed
             for future in futures.as_completed(future_results):
-                res = future.result()
-                for type_, name_, addr_ in res:
-                    if type_ in ['A', 'AAAA']:
-                        print_good(f'\t {type_} {name_} {addr_}')
-                        found_tlds.append([{'type': type_, 'name': name_, 'address': addr_}])
-            print_good(f'{len(found_tlds)} Records Found')
+                full_domain = future_results[future]
+                try:
+                    res_ = future.result()
+                    if res_:
+                        for type_, name_, addr_ in res_:
+                            if type_ in ['A', 'AAAA']:
+                                print_good(f'\t {type_} {name_} {addr_}')
+                                found_tlds.append({'type': type_, 'name': name_, 'address': addr_})
+                except Exception as e:
+                    print_error(f'Error resolving domain {full_domain}: {e}')
 
     except Exception as e:
-        print_error(e)
+        print_error(f'Error during brute force: {e}')
 
+    print_good(f'{len(found_tlds)} Records Found')
     return found_tlds
 
 

--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -287,6 +287,9 @@ def brute_tlds(res, domain, verbose=False, thread_num=None):
                     full_domain = f'{domain_main}.{cc}.{tld}'
                     future_results[executor.submit(res.get_ip, full_domain)] = full_domain
 
+                    if verbose:
+                        print_status(f'Queuing: {full_domain}')
+
             # Display results as soon as threads are completed
             for future in futures.as_completed(future_results):
                 full_domain = future_results[future]

--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -247,11 +247,22 @@ def brute_tlds(res, domain, verbose=False, thread_num=None):
     global brtdata
     brtdata = []
 
+    # https://en.wikipedia.org/wiki/Country_code_top-level_domain#Types
+    # https://www.iana.org/domains
+    # Taken from http://data.iana.org/TLD/tlds-alpha-by-domain.txt
     # Define TLDs and Country Code TLDs
     itld = ['arpa']
+
+    # Generic TLD
     gtld = TLDS.generic_tlds()
+
+    # Generic restricted TLD
     grtld = ['biz', 'name', 'pro']
+
+    # Sponsored TLD
     stld = TLDS.sponsored_tlds()
+
+    # Country Code TLD
     cctld = TLDS.country_codes()
 
     domain_main = domain.split('.')[0]


### PR DESCRIPTION
Attempting to address bug: https://github.com/darkoperator/dnsrecon/issues/213

Solution: Remove zip and use two sets of nested loops to handle the initialisation and completion.

I'm not 100% convinced this is a complete fix so someone else doing testing as well would be nice.

`dnsrecon.py -d microsoft.com -n 8.8.8.8 -f -a -s --threads 16 --lifetime 4 -c results.csv --disable_check_recursion -t tld -v` should be good enough, might want to tune threads though as google/cloudflare will rate limit you hard at a certain point.

Future upgrade would be to write output to a file as each thread is complete since this process takes insanely long to finish.