### PR TITLE
Fix some problems within brute_tlds function

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -249,7 +249,7 @@ def brute_tlds(res, domain, verbose=False, thread_num=None):
     tlds_list = get_list('https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat', 'lists/all_tld.txt')
     for tld in tlds_list.split('\n'):
         if '/' not in tld.strip() and tld.strip() != '':
-            total_tlds.append(tld.strip().lower().replace('*.',''))
+            total_tlds.append(tld.strip().lower().replace('*.', ''))
 
     # Let the user know how long it could take
     total_combinations = len(total_tlds)
@@ -261,7 +261,7 @@ def brute_tlds(res, domain, verbose=False, thread_num=None):
     try:
         with futures.ThreadPoolExecutor(max_workers=thread_num) as executor:
             future_results = {}
-         
+
             for tld in total_tlds:
                 full_domain = f'{domain_main}.{tld}'
                 future_results[executor.submit(res.get_ip, full_domain)] = full_domain

--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -55,7 +55,6 @@ from loguru import logger
 from dnsrecon.lib.bingenum import *
 from dnsrecon.lib.crtenum import scrape_crtsh
 from dnsrecon.lib.dnshelper import DnsHelper
-from dnsrecon.lib.tlds import TLDS
 from dnsrecon.lib.whois import *
 from dnsrecon.lib.yandexenum import *
 


### PR DESCRIPTION
The latest version on master tests only all combination of {basename}.{cc}.{tld}, but not the single {basename}.{cc} or {basename}.{tld}. Furthermore, most of the {cc}.{tld} are not valid combos, so there is a big wast of time.  I suggest to download the list taken from https://publicsuffix.org/, which is a complete and maintained list of all the possibile tlds.