### PR TITLE
Ensure provided nameservers are used in DNS queries

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -1838,6 +1838,7 @@ Possible types:
     spf_enum = arguments.s
     wildcard_filter = arguments.f
     proto = 'tcp' if arguments.tcp else 'udp'
+    ns_server = arguments.ns_server.split(',') if arguments.ns_server else []
 
     # Initialize an empty list to hold all records
     all_returned_records = []


### PR DESCRIPTION
This pull request addresses an issue where the `-n` / `--name_server` (nameserver) argument provided via the command line was not being utilized during DNS queries. The fix ensures that the nameservers passed as a comma-separated list to the --ns argument are properly split and stored in a list for use.