### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/dnsrecon/api.py
+++ b/dnsrecon/api.py
@@ -872,6 +872,13 @@ async def cache_snoop(
         # Use default wordlist if none provided
         if not wordlist:
             wordlist = os.path.join(os.path.dirname(__file__), 'data', 'namelist.txt')
+        else:
+            # Only allow wordlists within the data directory
+            data_dir = os.path.join(os.path.dirname(__file__), 'data')
+            requested_path = os.path.normpath(os.path.join(data_dir, wordlist))
+            if not requested_path.startswith(data_dir):
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid wordlist path')
+            wordlist = requested_path
 
         if not os.path.exists(wordlist):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Wordlist file not found')


### PR DESCRIPTION
Potential fix for [https://github.com/darkoperator/dnsrecon/security/code-scanning/22](https://github.com/darkoperator/dnsrecon/security/code-scanning/22)

To fix this issue, we need to ensure that the user-supplied `wordlist` path cannot be used to access files outside of a designated safe directory (e.g., a `data` directory within the application). The best way to do this is to:

1. Define a safe root directory for wordlists (e.g., `data` directory relative to the current file).
2. When a user supplies a `wordlist` value, join it with the safe root directory, normalize the resulting path, and check that it is still within the safe root directory.
3. If the check fails, reject the request with an error.
4. If the check passes, proceed as before.

This approach allows users to select from files within the allowed directory, but prevents path traversal or absolute path attacks. We will need to add code to compute the safe root, normalize the path, and check the prefix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
