### PR TITLE
fix(cli): general_enum Yandex scraper + dead 'address' guard

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -1390,17 +1390,17 @@ def general_enum(
             bing_rcd = se_result_process(res, domain, scrape_bing(domain))
             if bing_rcd:
                 for r in bing_rcd:
-                    if 'address' in bing_rcd:
+                    if 'address' in r:
                         ip_for_whois.append(r['address'])
                 returned_records.extend(bing_rcd)
 
         # Do Yandex Search enumeration if selected
         if do_yandex:
             logger.info('Performing Yandex Search Enumeration')
-            yandex_rcd = se_result_process(res, domain, scrape_bing(domain))
+            yandex_rcd = se_result_process(res, domain, scrape_yandex(domain))
             if yandex_rcd:
                 for r in yandex_rcd:
-                    if 'address' in yandex_rcd:
+                    if 'address' in r:
                         ip_for_whois.append(r['address'])
                 returned_records.extend(yandex_rcd)
 
@@ -1409,7 +1409,7 @@ def general_enum(
             crt_rcd = se_result_process(res, domain, scrape_crtsh(domain))
             if crt_rcd:
                 for r in crt_rcd:
-                    if 'address' in crt_rcd:
+                    if 'address' in r:
                         ip_for_whois.append(r['address'])
                 returned_records.extend(crt_rcd)
 

--- a/tests/test_dnsrecon.py
+++ b/tests/test_dnsrecon.py
@@ -2,6 +2,65 @@ from unittest.mock import patch, MagicMock
 from dnsrecon import cli
 
 
+def _stub_resolver_minimal():
+    """MagicMock resolver with all DnsHelper methods stubbed to return empty/None."""
+    res = MagicMock()
+    res.get_soa.return_value = []
+    res.get_ns.return_value = []
+    res.get_mx.return_value = []
+    res.get_ip.return_value = []
+    res.get_spf.return_value = None
+    res.get_txt.return_value = []
+    res.zone_transfer.return_value = None
+    return res
+
+
+def test_general_enum_yandex_branch_calls_scrape_yandex():
+    """Yandex enumeration must call scrape_yandex(), not scrape_bing() (issue #505)."""
+    res = _stub_resolver_minimal()
+    with patch('dnsrecon.cli.check_wildcard', return_value=set()), \
+            patch('dnsrecon.cli.dns_sec_check'), \
+            patch('dnsrecon.cli.brute_srv', return_value=[]), \
+            patch('dnsrecon.cli.scrape_yandex', return_value=[]) as mock_yandex, \
+            patch('dnsrecon.cli.scrape_bing') as mock_bing:
+        cli.general_enum(
+            res=res, domain='example.com',
+            do_axfr=False, do_bing=False, do_yandex=True, do_spf=False,
+            do_whois=False, do_crt=False, zw=False, request_timeout=3.0,
+        )
+
+    mock_yandex.assert_called_once_with('example.com')
+    mock_bing.assert_not_called()
+
+
+def test_general_enum_bing_addresses_feed_whois(monkeypatch):
+    """Addresses discovered via Bing must be forwarded to WHOIS (issue #506)."""
+    res = _stub_resolver_minimal()
+    bing_records = [
+        {'type': 'A', 'name': 'a.example.com', 'address': '192.0.2.1', 'domain': 'example.com'},
+        {'type': 'CNAME', 'name': 'b.example.com', 'target': 'a.example.com', 'domain': 'example.com'},
+    ]
+    seen_ips = []
+
+    def fake_whois_ips(res_arg, ip_list, whois_ranges=None):
+        seen_ips.extend(ip_list)
+        return None
+
+    with patch('dnsrecon.cli.check_wildcard', return_value=set()), \
+            patch('dnsrecon.cli.dns_sec_check'), \
+            patch('dnsrecon.cli.brute_srv', return_value=[]), \
+            patch('dnsrecon.cli.scrape_bing', return_value=['a.example.com', 'b.example.com']), \
+            patch('dnsrecon.cli.se_result_process', return_value=bing_records), \
+            patch('dnsrecon.cli.whois_ips', side_effect=fake_whois_ips):
+        cli.general_enum(
+            res=res, domain='example.com',
+            do_axfr=False, do_bing=True, do_yandex=False, do_spf=False,
+            do_whois=True, do_crt=False, zw=False, request_timeout=3.0,
+        )
+
+    assert '192.0.2.1' in seen_ips, f'Bing address not propagated to WHOIS: {seen_ips!r}'
+
+
 def test_check_wildcard():
     with patch('dnsrecon.lib.dnshelper.DnsHelper') as mock_dns_helper:
         mock_instance = mock_dns_helper.return_value


### PR DESCRIPTION
## Summary

Fixes two small pre-existing bugs in `general_enum()` that I noticed while working on #503 / #504 and filed as separate issues:

- Closes #505 — Yandex branch calls `scrape_bing()` instead of `scrape_yandex()`, so `-y` / `-t yand` via `general_enum` runs Bing twice and labels the result as Yandex.
- Closes #506 — The guard `if 'address' in bing_rcd` (and the `yandex_rcd` / `crt_rcd` variants) checks a string against a list of dicts; always `False`, so `ip_for_whois.append(r['address'])` is dead code. Addresses discovered via the three search-engine enumerators never reach the WHOIS / Shodan step.

## Changes

`dnsrecon/cli.py` — 4-line diff inside `general_enum`:

```diff
-            yandex_rcd = se_result_process(res, domain, scrape_bing(domain))
+            yandex_rcd = se_result_process(res, domain, scrape_yandex(domain))
```

and, in each of the Bing / Yandex / crt.sh branches:

```diff
-                    if 'address' in bing_rcd:
+                    if 'address' in r:
```

## Files Changed

| File | Change | Lines |
|---|---|---|
| `dnsrecon/cli.py` | Modified | +4 / -4 |
| `tests/test_dnsrecon.py` | Modified | +59 |

## Testing

Two new regression tests, both passing:

- `test_general_enum_yandex_branch_calls_scrape_yandex` — asserts the Yandex branch calls `scrape_yandex` and not `scrape_bing` (guards #505).
- `test_general_enum_bing_addresses_feed_whois` — mocks `se_result_process` to return a record with `address: 192.0.2.1`, then asserts `whois_ips` is invoked with an IP list containing that address (guards #506).

Full suite: **55 passed** in 4.41s. `ruff check` clean.

## Related issues

- Closes #505
- Closes #506
- Related to #503 / #504 (independent; this PR is based on current `master`, not on the #504 branch — if #504 merges first, a trivial rebase is required)