### PR TITLE
general_enum: don't crash the whole scan on crt.sh transient HTTP errors

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -1406,7 +1406,17 @@ def general_enum(
 
         if do_crt:
             logger.info('Performing Crt.sh Search Enumeration')
-            crt_rcd = se_result_process(res, domain, scrape_crtsh(domain))
+            # crt.sh has a habit of returning 502/503 in bursts. After
+            # stamina.retry exhausts its attempts inside scrape_crtsh, an
+            # httpx.HTTPStatusError propagates out and would otherwise abort
+            # the entire scan, discarding everything collected so far. Treat
+            # any third-party HTTP failure as "no records from this source"
+            # and keep going (issue #503).
+            crt_rcd = None
+            try:
+                crt_rcd = se_result_process(res, domain, scrape_crtsh(domain))
+            except httpx.HTTPError as e:
+                logger.warning(f'crt.sh enumeration failed, continuing without it: {e}')
             if crt_rcd:
                 for r in crt_rcd:
                     if 'address' in crt_rcd:
@@ -2198,7 +2208,13 @@ Possible types:
 
                 elif type_ == 'crt':
                     logger.info(f'{type_}: Performing Crt.sh Search Enumeration against {domain}...')
-                    crt_enum_records = se_result_process(res, domain, scrape_crtsh(domain))
+                    # See issue #503 — crt.sh outages would otherwise crash
+                    # the entire scan after retries are exhausted.
+                    crt_enum_records = None
+                    try:
+                        crt_enum_records = se_result_process(res, domain, scrape_crtsh(domain))
+                    except httpx.HTTPError as e:
+                        logger.warning(f'crt.sh enumeration failed: {e}')
                     if crt_enum_records is not None and do_output:
                         all_returned_records.extend(crt_enum_records)
                     else:


### PR DESCRIPTION
Closes #503.

When crt.sh returns sustained 5xx (a known periodic occurrence on the public crt.sh instance), `scrape_crtsh` exhausts its `stamina.retry` attempts and then re-raises `httpx.HTTPStatusError`. The two call sites in `cli.py` — inside `general_enum` and inside the top-level dispatcher in `main()` — call `scrape_crtsh` inline with no surrounding `try/except`, so the exception propagates out of `main()` and **aborts the entire scan**, discarding everything collected so far (SOA/NS/MX/A/TXT/SPF-PTR records). No output file is written because the crash happens before the output-writing block.

### Fix

Wrap each `scrape_crtsh` call in a narrow `try/except httpx.HTTPError`. On failure we log a warning at WARN level and continue with `crt_rcd = None`/`crt_enum_records = None`, so:
- the rest of `general_enum` continues normally
- the rest of `main()`'s scan-type dispatcher continues normally
- already-collected records still get written to the output file

`httpx.HTTPError` is the parent class of both `HTTPStatusError` and `TimeoutException`, so this also covers the `httpx.TimeoutException` and `httpx.HTTPError` paths the issue mentioned.

`httpx` was already an import in `cli.py:46`, so no new dependencies.

### Verification
```
$ python3 -m pytest tests/
============================== 53 passed in 2.46s ==============================
```