### PR TITLE
whois_ips: skip the interactive prompt when stdin is not a TTY

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -848,10 +848,21 @@ def whois_ips(res, ip_list, whois_ranges=None):
                     list_whois[i]['orgname'],
                 )
             )
-        logger.info('What Range do you wish to do a Reverse Lookup for?')
-        logger.info('number, comma separated list, a for all or n for none')
-        val = sys.stdin.readline()[:-1]
-        answer = str(val).split(',')
+        # If stdin is not an interactive terminal (REST API call, CI pipeline,
+        # piped input, container without -it, …) blocking on
+        # sys.stdin.readline() either hangs forever or silently returns an
+        # empty string. Default to "all" in that case, which matches the
+        # most-useful behavior for automated scans (issue #508). Users who
+        # want a different non-interactive default can pass whois_ranges
+        # directly from a wrapper.
+        if not sys.stdin.isatty():
+            logger.info('Non-interactive stdin detected; defaulting WHOIS reverse-lookup to all ranges')
+            answer = ['a']
+        else:
+            logger.info('What Range do you wish to do a Reverse Lookup for?')
+            logger.info('number, comma separated list, a for all or n for none')
+            val = sys.stdin.readline()[:-1]
+            answer = str(val).split(',')
 
         if 'a' in answer:
             for i in range(len(list_whois)):


### PR DESCRIPTION
Closes #508.

`whois_ips()` blocks on `sys.stdin.readline()` to ask which discovered WHOIS IP ranges to reverse-lookup. That is fine in a real terminal, but the same code path runs whenever `-w` is set, including via:

- the REST API in `dnsrecon/api.py` (`do_whois=true`) — the request hangs until client/server timeout
- CI / cron / scripted runs piped from stdin
- `docker run` without `-it` (no controlling terminal)

With stdin closed, `readline()` returns `''` and the prompt silently selects nothing. With stdin attached to a TTY-less process, the call blocks indefinitely.

### Fix

Detect non-interactive stdin via `sys.stdin.isatty()` and default to "all ranges" (matches what the existing `a` choice does, and is the most-useful behavior for automated scans). The interactive prompt is preserved verbatim for terminal users.

```python
if not sys.stdin.isatty():
    logger.info('Non-interactive stdin detected; defaulting WHOIS reverse-lookup to all ranges')
    answer = ['a']
else:
    # original prompt path, unchanged
```

The existing `whois_ranges=` parameter already lets a caller pre-compute the selection, so a future `--whois-ranges` CLI flag or REST API parameter can be added on top without touching this function again.

### Verification
```
$ python3 -m pytest tests/
============================== 53 passed in 2.4s ==============================
```