### PR TITLE
Fix API validation and safe DB writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,11 @@ curl -s \
   "http://127.0.0.1:5000/general_enum?domain=example.com&do_spf=true&do_whois=true&do_shodan=true&shodan_active=true"
 ```
 
+REST API `thread_num` values are limited to `1..100`. API `wordlist` parameters may reference bundled files in `dnsrecon/data` or files under directories listed in `DNSRECON_WORDLIST_DIRS` using the platform path separator, for example:
+
+```bash
+export DNSRECON_WORDLIST_DIRS="/opt/dnsrecon-wordlists:/srv/shared-wordlists"
+```
+
 ## Packaging Versions
 [![Packaging status](https://repology.org/badge/vertical-allrepos/dnsrecon.svg)](https://repology.org/project/dnsrecon/versions)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ curl -s \
   "http://127.0.0.1:5000/general_enum?domain=example.com&do_spf=true&do_whois=true&do_shodan=true&shodan_active=true"
 ```
 
-REST API `thread_num` values are limited to `1..100`. API `wordlist` parameters may reference bundled files in `dnsrecon/data` or files under directories listed in `DNSRECON_WORDLIST_DIRS` using the platform path separator, for example:
+REST API `thread_num` values are limited to `1..100`. API `wordlist` parameters may reference bundled files in `dnsrecon/data` or files under directories listed in `DNSRECON_WORDLIST_DIRS` using the platform path separator. Configure only dedicated wordlist directories; do not point `DNSRECON_WORDLIST_DIRS` at broad paths such as `/`, a home directory, or other locations containing sensitive files.
 
 ```bash
 export DNSRECON_WORDLIST_DIRS="/opt/dnsrecon-wordlists:/srv/shared-wordlists"

--- a/dnsrecon/api.py
+++ b/dnsrecon/api.py
@@ -1,5 +1,7 @@
+import ipaddress
 import os
 import traceback
+from pathlib import Path
 
 from fastapi import FastAPI, Header, HTTPException, Query, Request, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -21,10 +23,58 @@ from dnsrecon.cli import (
     ds_zone_walk,
     general_enum,
     in_cache,
+    process_range,
 )
 from dnsrecon.lib.dnshelper import DnsHelper
 
 API_RATE_LIMIT = os.getenv('API_RATE_LIMIT', '5/minute')
+API_MAX_THREADS = 100
+DATA_DIR = Path(__file__).parent / 'data'
+
+
+def _bad_request(detail: str) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+
+def validate_thread_num(thread_num: int) -> int:
+    if thread_num < 1 or thread_num > API_MAX_THREADS:
+        raise _bad_request(f'thread_num must be between 1 and {API_MAX_THREADS}')
+    return thread_num
+
+
+def wordlist_roots() -> list[Path]:
+    roots = [DATA_DIR.resolve()]
+    for root in os.getenv('DNSRECON_WORDLIST_DIRS', '').split(os.pathsep):
+        if root:
+            roots.append(Path(root).expanduser().resolve())
+    return roots
+
+
+def resolve_wordlist_path(wordlist: str, default_filename: str) -> str:
+    candidate = DATA_DIR / default_filename if not wordlist else Path(wordlist).expanduser()
+    allowed_roots = wordlist_roots()
+
+    if wordlist and not candidate.is_absolute():
+        relative_candidates = [root / candidate for root in allowed_roots]
+    else:
+        relative_candidates = [candidate]
+
+    matched_allowed_root = False
+    for possible_path in relative_candidates:
+        resolved = possible_path.resolve()
+        for root in allowed_roots:
+            try:
+                resolved.relative_to(root)
+            except ValueError:
+                continue
+            matched_allowed_root = True
+            if not resolved.is_file():
+                continue
+            return str(resolved)
+
+    if matched_allowed_root:
+        raise _bad_request('Wordlist file not found')
+    raise _bad_request('Invalid wordlist path')
 
 
 # Define Pydantic models for request and response validation
@@ -267,6 +317,8 @@ async def general_enumeration(
         if not domain or len(domain) < 3:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Domain must be at least 3 characters long')
 
+        thread_num = validate_thread_num(thread_num)
+
         # Create DNS resolver
         res = DnsHelper(domain, recursion_desired=recursion_desired)
 
@@ -369,17 +421,12 @@ async def brute_force_domain(
         if not domain or len(domain) < 3:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Domain must be at least 3 characters long')
 
+        thread_num = validate_thread_num(thread_num)
+
         # Create a DNS resolver
         res = DnsHelper(domain, recursion_desired=recursion_desired)
 
-        # Use default wordlist if none provided
-        safe_root = os.path.join(os.path.dirname(__file__), 'data')
-        if not wordlist:
-            wordlist = os.path.join(safe_root, 'subdomains-top1mil-5000.txt')
-        else:
-            wordlist = os.path.normpath(os.path.join(safe_root, wordlist))
-            if not wordlist.startswith(safe_root):
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid wordlist path')
+        wordlist = resolve_wordlist_path(wordlist, 'subdomains-top1mil-5000.txt')
 
         results = brute_domain(
             res=res,
@@ -460,14 +507,18 @@ async def brute_force_reverse(
         if not ip_range:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='IP range is required')
 
-        # Parse IP range
-        if '-' in ip_range:
-            start_ip, end_ip = ip_range.split('-', 1)
-            ip_list = [
-                f'{start_ip.rsplit(".", 1)[0]}.{i}' for i in range(int(start_ip.split('.')[-1]), int(end_ip.split('.')[-1]) + 1)
-            ]
+        thread_num = validate_thread_num(thread_num)
+
+        if '-' in ip_range or '/' in ip_range:
+            ip_list = process_range(ip_range)
         else:
-            ip_list = [ip_range]
+            try:
+                ip_list = [ipaddress.ip_address(ip_range)]
+            except ValueError as e:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid IP range') from e
+
+        if not ip_list:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid IP range')
 
         res = DnsHelper('example.com', recursion_desired=recursion_desired)  # Domain not used for reverse lookups
 
@@ -598,6 +649,7 @@ async def brute_force_srv(
         if not domain or len(domain) < 3:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Domain must be at least 3 characters long')
 
+        thread_num = validate_thread_num(thread_num)
         res = DnsHelper(domain, recursion_desired=recursion_desired)
 
         # Perform SRV enumeration
@@ -672,6 +724,7 @@ async def brute_force_tlds(
         if not domain or len(domain) < 3:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Domain must be at least 3 characters long')
 
+        thread_num = validate_thread_num(thread_num)
         res = DnsHelper(domain, recursion_desired=recursion_desired)
 
         # Perform TLD enumeration
@@ -751,7 +804,9 @@ async def axfr_test(
 
         # Process results
         records = []
-        zone_transfer_successful = bool(results)
+        zone_transfer_successful = any(
+            isinstance(result, dict) and result.get('zone_transfer') == 'success' for result in results or []
+        )
 
         if results:
             for result in results:
@@ -891,19 +946,7 @@ async def cache_snoop(
         if not nameserver:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Name server is required')
 
-        # Use default wordlist if none provided
-        if not wordlist:
-            wordlist = os.path.join(os.path.dirname(__file__), 'data', 'namelist.txt')
-        else:
-            # Only allow wordlists within the data directory
-            data_dir = os.path.join(os.path.dirname(__file__), 'data')
-            requested_path = os.path.normpath(os.path.join(data_dir, wordlist))
-            if not requested_path.startswith(data_dir):
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid wordlist path')
-            wordlist = requested_path
-
-        if not os.path.exists(wordlist):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Wordlist file not found')
+        wordlist = resolve_wordlist_path(wordlist, 'namelist.txt')
 
         res = DnsHelper('example.com')  # Domain not critical for cache snooping
 

--- a/dnsrecon/api.py
+++ b/dnsrecon/api.py
@@ -51,15 +51,7 @@ def wordlist_roots() -> list[Path]:
 
 
 def resolve_wordlist_path(wordlist: str, default_filename: str) -> str:
-    if not wordlist:
-        candidate = DATA_DIR / default_filename
-    else:
-        # Accept only a simple filename from user input to avoid path traversal
-        # or absolute/relative path injection.
-        if wordlist != os.path.basename(wordlist) or any(sep in wordlist for sep in ('/', '\\')) or '..' in wordlist:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid wordlist path')
-        candidate = DATA_DIR / wordlist
-
+    candidate = DATA_DIR / default_filename if not wordlist else Path(wordlist).expanduser()
     allowed_roots = wordlist_roots()
 
     if wordlist and not candidate.is_absolute():

--- a/dnsrecon/api.py
+++ b/dnsrecon/api.py
@@ -51,7 +51,15 @@ def wordlist_roots() -> list[Path]:
 
 
 def resolve_wordlist_path(wordlist: str, default_filename: str) -> str:
-    candidate = DATA_DIR / default_filename if not wordlist else Path(wordlist).expanduser()
+    if not wordlist:
+        candidate = DATA_DIR / default_filename
+    else:
+        # Accept only a simple filename from user input to avoid path traversal
+        # or absolute/relative path injection.
+        if wordlist != os.path.basename(wordlist) or any(sep in wordlist for sep in ('/', '\\')) or '..' in wordlist:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Invalid wordlist path')
+        candidate = DATA_DIR / wordlist
+
     allowed_roots = wordlist_roots()
 
     if wordlist and not candidate.is_absolute():

--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -607,6 +607,10 @@ def brute_reverse(res, ip_list, verbose=False, thread_num=None):
         else:
             expanded_ips.append(entry)
 
+    if not expanded_ips:
+        logger.error('No IP addresses provided for reverse lookup')
+        return []
+
     start_ip = expanded_ips[0]
     end_ip = expanded_ips[-1]
     logger.info(f'Performing Reverse Lookup from {start_ip} to {end_ip}')
@@ -1037,64 +1041,54 @@ def write_db(db, data):
 
     # Normalize the dictionary data
     for n in data:
-        if re.match(r'PTR|^[A]$|AAAA', n['type']):
-            query = (
-                'insert into data( domain, type, name, address ) '
-                + 'values( "{domain}", "{type}", "{name}", "{address}" )'.format(**n)
-            )
+        record_type = n['type']
+        domain = n.get('domain', '')
 
-        elif re.match(r'NS$', n['type']):
-            query = (
-                'insert into data( domain, type, name, address ) '
-                + 'values( "{domain}", "{type}", "{target}", "{address}" )'.format(**n)
-            )
+        if re.match(r'PTR|^[A]$|AAAA', record_type):
+            query = 'insert into data( domain, type, name, address ) values( ?, ?, ?, ? )'
+            params = (domain, record_type, n.get('name', ''), n.get('address', ''))
 
-        elif re.match(r'SOA', n['type']):
-            query = (
-                'insert into data( domain, type, name, address ) '
-                + 'values( "{domain}", "{type}", "{mname}", "{address}" )'.format(**n)
-            )
+        elif re.match(r'NS$', record_type):
+            query = 'insert into data( domain, type, name, address ) values( ?, ?, ?, ? )'
+            params = (domain, record_type, n.get('target', ''), n.get('address', ''))
 
-        elif re.match(r'MX', n['type']):
-            query = (
-                'insert into data( domain, type, name, address ) '
-                + 'values( "{domain}", "{type}", "{exchange}", "{address}" )'.format(**n)
-            )
+        elif re.match(r'SOA', record_type):
+            query = 'insert into data( domain, type, name, address ) values( ?, ?, ?, ? )'
+            params = (domain, record_type, n.get('mname', ''), n.get('address', ''))
 
-        elif re.match(r'TXT', n['type']):
-            query = 'insert into data( domain, type, text) ' + 'values( "{domain}", "{type}", "{strings}" )'.format(**n)
+        elif re.match(r'MX', record_type):
+            query = 'insert into data( domain, type, name, address ) values( ?, ?, ?, ? )'
+            params = (domain, record_type, n.get('exchange', ''), n.get('address', ''))
 
-        elif re.match(r'SPF', n['type']):
-            query = 'insert into data( domain, type, text) ' + 'values( "{domain}", "{type}", "{strings}" )'.format(**n)
+        elif re.match(r'TXT', record_type):
+            query = 'insert into data( domain, type, text) values( ?, ?, ? )'
+            params = (domain, record_type, n.get('strings', ''))
 
-        elif re.match(r'SRV', n['type']):
-            query = (
-                'insert into data( domain, type, name, target, address, port ) '
-                + 'values( "{domain}", "{type}", "{name}", "{target}", "{address}", "{port}" )'.format(**n)
-            )
+        elif re.match(r'SPF', record_type):
+            query = 'insert into data( domain, type, text) values( ?, ?, ? )'
+            params = (domain, record_type, n.get('strings', ''))
 
-        elif re.match(r'CNAME', n['type']):
-            query = (
-                'insert into data( domain, type, name, target ) '
-                + 'values( "{domain}", "{type}", "{name}", "{target}" )'.format(**n)
-            )
-        elif re.match(r'CAA', n['type']):
+        elif re.match(r'SRV', record_type):
+            query = 'insert into data( domain, type, name, target, address, port ) values( ?, ?, ?, ?, ?, ? )'
+            params = (domain, record_type, n.get('name', ''), n.get('target', ''), n.get('address', ''), n.get('port', ''))
+
+        elif re.match(r'CNAME', record_type):
+            query = 'insert into data( domain, type, name, target ) values( ?, ?, ?, ? )'
+            params = (domain, record_type, n.get('name', ''), n.get('target', ''))
+        elif re.match(r'CAA', record_type):
             # Preserve some of the previous behavior when writing CAA records to the database would fall into the else clause
             text = ','.join([f'{key}={value}' for key, value in n.items() if key != 'type'])
-            query = "insert into data( domain, type, name, target, address, text ) values ('{domain}', '{type}', '{name}', '{target}', '{address}', '{text}')".format(
-                **n, text=text
-            )
+            query = 'insert into data( domain, type, name, target, address, text ) values (?, ?, ?, ?, ?, ?)'
+            params = (domain, record_type, n.get('name', ''), n.get('target', ''), n.get('address', ''), text)
 
         else:
             # Handle not common records
-            t = n['type']
-            del n['type']
-            record_data = ''.join([f'{key}={value},' for key, value in n.items()])
-            records = [t, record_data]
-            query = 'insert into data( domain, type, text ) values ("%(domain)", \'' + records[0] + "', '" + records[1] + "')"
+            record_data = ''.join([f'{key}={value},' for key, value in n.items() if key != 'type'])
+            query = 'insert into data( domain, type, text ) values (?, ?, ?)'
+            params = (domain, record_type, record_data)
 
         # Execute Query and commit
-        cur.execute(query)
+        cur.execute(query, params)
         con.commit()
 
 
@@ -1174,7 +1168,7 @@ def check_recursive(res, ns_server, timeout):
             result = re.findall(recursion_flag_pattern, flags)
             if result:
                 logger.error(f'\t Recursion enabled on NS Server {ns_server}')
-            is_recursive = True
+                is_recursive = True
         except (OSError, dns.exception.Timeout):
             pass
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -146,6 +146,48 @@ class TestDNSReconAPI:
         assert "subdomains" in data
         assert "records" in data
         assert isinstance(data["records"], list)
+
+    @patch('dnsrecon.api.brute_domain')
+    @patch('dnsrecon.api.DnsHelper')
+    def test_brute_domain_accepts_configured_wordlist_dir(self, mock_dns_helper, mock_brute_domain, client, tmp_path, monkeypatch):
+        """Wordlists may live outside bundled data when explicitly configured."""
+        wordlist = tmp_path / "custom.txt"
+        wordlist.write_text("www\n")
+        monkeypatch.setenv("DNSRECON_WORDLIST_DIRS", str(tmp_path))
+        mock_dns_helper.return_value = MagicMock()
+        mock_brute_domain.return_value = []
+
+        response = client.get(f"/brute_domain?domain=example.com&wordlist={wordlist}")
+
+        assert response.status_code == 200
+        assert mock_brute_domain.call_args.kwargs["dictfile"] == str(wordlist.resolve())
+
+    def test_brute_domain_rejects_unconfigured_absolute_wordlist(self, client, tmp_path, monkeypatch):
+        wordlist = tmp_path / "custom.txt"
+        wordlist.write_text("www\n")
+        monkeypatch.delenv("DNSRECON_WORDLIST_DIRS", raising=False)
+
+        response = client.get(f"/brute_domain?domain=example.com&wordlist={wordlist}")
+
+        assert response.status_code == 400
+
+    def test_brute_domain_rejects_symlink_escape(self, client, tmp_path, monkeypatch):
+        allowed = tmp_path / "allowed"
+        outside = tmp_path / "outside"
+        allowed.mkdir()
+        outside.mkdir()
+        real_wordlist = outside / "custom.txt"
+        real_wordlist.write_text("www\n")
+        symlink = allowed / "link.txt"
+        try:
+            symlink.symlink_to(real_wordlist)
+        except OSError:
+            pytest.skip("symlinks are not supported on this platform")
+
+        monkeypatch.setenv("DNSRECON_WORDLIST_DIRS", str(allowed))
+        response = client.get("/brute_domain?domain=example.com&wordlist=link.txt")
+
+        assert response.status_code == 400
     
     @patch('dnsrecon.api.brute_reverse')
     @patch('dnsrecon.api.DnsHelper')
@@ -166,6 +208,26 @@ class TestDNSReconAPI:
         assert "ip_range" in data
         assert "records" in data
         assert isinstance(data["records"], list)
+
+    @patch('dnsrecon.api.brute_reverse')
+    @patch('dnsrecon.api.DnsHelper')
+    def test_brute_reverse_accepts_cross_subnet_range(self, mock_dns_helper, mock_brute_reverse, client):
+        mock_dns_helper.return_value = MagicMock()
+        mock_brute_reverse.return_value = []
+
+        response = client.get("/brute_reverse?ip_range=192.0.2.254-192.0.3.1")
+
+        assert response.status_code == 200
+        ip_list = mock_brute_reverse.call_args.kwargs["ip_list"]
+        assert [str(ip) for ip in ip_list] == ["192.0.2.254", "192.0.2.255", "192.0.3.0", "192.0.3.1"]
+
+    def test_brute_reverse_invalid_ip_range_returns_400(self, client):
+        response = client.get("/brute_reverse?ip_range=not-an-ip")
+        assert response.status_code == 400
+
+    def test_brute_reverse_rejects_excessive_thread_count(self, client):
+        response = client.get("/brute_reverse?ip_range=192.0.2.1&thread_num=101")
+        assert response.status_code == 400
     
     def test_brute_reverse_missing_ip_range(self, client):
         """Test reverse DNS brute force with missing IP range"""
@@ -253,6 +315,32 @@ class TestDNSReconAPI:
         assert "zone_transfer_successful" in data
         assert "records" in data
         assert isinstance(data["records"], list)
+
+    @patch('dnsrecon.api.DnsHelper')
+    def test_axfr_test_failure_info_is_not_success(self, mock_dns_helper, client):
+        mock_instance = MagicMock()
+        mock_dns_helper.return_value = mock_instance
+        mock_instance.zone_transfer.return_value = [
+            {'type': 'info', 'zone_transfer': 'failed', 'ns_server': '192.0.2.53'}
+        ]
+
+        response = client.get("/axfr_test?domain=example.com")
+
+        assert response.status_code == 200
+        assert response.json()["zone_transfer_successful"] is False
+
+    @patch('dnsrecon.api.DnsHelper')
+    def test_axfr_test_success_info_is_success(self, mock_dns_helper, client):
+        mock_instance = MagicMock()
+        mock_dns_helper.return_value = mock_instance
+        mock_instance.zone_transfer.return_value = [
+            {'type': 'info', 'zone_transfer': 'success', 'ns_server': '192.0.2.53'}
+        ]
+
+        response = client.get("/axfr_test?domain=example.com")
+
+        assert response.status_code == 200
+        assert response.json()["zone_transfer_successful"] is True
     
     @patch('dnsrecon.lib.dnshelper.DnsHelper.get_caa')
     @patch('dnsrecon.api.DnsHelper')
@@ -293,6 +381,20 @@ class TestDNSReconAPI:
         assert data["nameserver"] == "8.8.8.8"
         assert "cached_records" in data
         assert isinstance(data["cached_records"], list)
+
+    @patch('dnsrecon.api.in_cache')
+    @patch('dnsrecon.api.DnsHelper')
+    def test_cache_snoop_accepts_configured_wordlist_dir(self, mock_dns_helper, mock_in_cache, client, tmp_path, monkeypatch):
+        wordlist = tmp_path / "cache.txt"
+        wordlist.write_text("example.com\n")
+        monkeypatch.setenv("DNSRECON_WORDLIST_DIRS", str(tmp_path))
+        mock_dns_helper.return_value = MagicMock()
+        mock_in_cache.return_value = []
+
+        response = client.get(f"/cache_snoop?nameserver=8.8.8.8&wordlist={wordlist}")
+
+        assert response.status_code == 200
+        assert mock_in_cache.call_args.kwargs["dict_file"] == str(wordlist.resolve())
     
     def test_cache_snoop_missing_nameserver(self, client):
         """Test cache snooping with missing nameserver"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -157,7 +157,7 @@ class TestDNSReconAPI:
         mock_dns_helper.return_value = MagicMock()
         mock_brute_domain.return_value = []
 
-        response = client.get(f"/brute_domain?domain=example.com&wordlist={wordlist}")
+        response = client.get("/brute_domain", params={"domain": "example.com", "wordlist": str(wordlist)})
 
         assert response.status_code == 200
         assert mock_brute_domain.call_args.kwargs["dictfile"] == str(wordlist.resolve())
@@ -167,7 +167,7 @@ class TestDNSReconAPI:
         wordlist.write_text("www\n")
         monkeypatch.delenv("DNSRECON_WORDLIST_DIRS", raising=False)
 
-        response = client.get(f"/brute_domain?domain=example.com&wordlist={wordlist}")
+        response = client.get("/brute_domain", params={"domain": "example.com", "wordlist": str(wordlist)})
 
         assert response.status_code == 400
 
@@ -391,7 +391,7 @@ class TestDNSReconAPI:
         mock_dns_helper.return_value = MagicMock()
         mock_in_cache.return_value = []
 
-        response = client.get(f"/cache_snoop?nameserver=8.8.8.8&wordlist={wordlist}")
+        response = client.get("/cache_snoop", params={"nameserver": "8.8.8.8", "wordlist": str(wordlist)})
 
         assert response.status_code == 200
         assert mock_in_cache.call_args.kwargs["dict_file"] == str(wordlist.resolve())

--- a/tests/test_dnsrecon.py
+++ b/tests/test_dnsrecon.py
@@ -255,18 +255,49 @@ def test_write_db():
             {"domain": "zonetransfer.me", "type": "OTHER", "name": "zonetransfer.me", "strings": "spf.zonetransfer.me"},
         ])
         assert cursor.execute.call_count == 12
-        assert cursor.execute.call_args_list[0][0][0] == 'insert into data( domain, type, name, address ) values( "zonetransfer.me", "A", "zonetransfer.me", "192.0.2.1" )'
-        assert cursor.execute.call_args_list[1][0][0] == "insert into data( domain, type, name, target, address, text ) values ('zonetransfer.me', 'CAA', 'zonetransfer.me', 'example.com', '192.0.2.1', 'domain=zonetransfer.me,name=zonetransfer.me,address=192.0.2.1,target=example.com')"
-        assert cursor.execute.call_args_list[2][0][0] == 'insert into data( domain, type, name, target ) values( "zonetransfer.me", "CNAME", "zonetransfer.me", "some.domain.com" )'
-        assert cursor.execute.call_args_list[3][0][0] == 'insert into data( domain, type, name, address ) values( "zonetransfer.me", "AAAA", "zonetransfer.me", "2001:db8::1" )'
-        assert cursor.execute.call_args_list[4][0][0] == 'insert into data( domain, type, name, address ) values( "zonetransfer.me", "MX", "mail.zonetransfer.me", "192.0.2.1" )'
-        assert cursor.execute.call_args_list[5][0][0] == 'insert into data( domain, type, text) values( "zonetransfer.me", "TXT", "txt.zonetransfer.me" )'
-        assert cursor.execute.call_args_list[6][0][0] == 'insert into data( domain, type, name, address ) values( "zonetransfer.me", "NS", "ns.zonetransfer.me", "192.0.2.1" )'
-        assert cursor.execute.call_args_list[7][0][0] == 'insert into data( domain, type, name, address ) values( "zonetransfer.me", "SOA", "soa.zonetransfer.me", "192.0.2.1" )'
-        assert cursor.execute.call_args_list[8][0][0] == 'insert into data( domain, type, name, target, address, port ) values( "zonetransfer.me", "SRV", "zonetransfer.me", "srv.zonetransfer.me", "192.0.2.1", "80" )'
-        assert cursor.execute.call_args_list[9][0][0] == 'insert into data( domain, type, text) values( "zonetransfer.me", "SPF", "spf.zonetransfer.me" )'
-        assert cursor.execute.call_args_list[10][0][0] == 'insert into data( domain, type, name, address ) values( "zonetransfer.me", "PTR", "zonetransfer.me", "192.0.2.1" )'
-        assert cursor.execute.call_args_list[11][0][0] == 'insert into data( domain, type, text ) values ("%(domain)", \'OTHER\', \'domain=zonetransfer.me,name=zonetransfer.me,strings=spf.zonetransfer.me,\')'
+        assert cursor.execute.call_args_list[0][0] == (
+            'insert into data( domain, type, name, address ) values( ?, ?, ?, ? )',
+            ('zonetransfer.me', 'A', 'zonetransfer.me', '192.0.2.1'),
+        )
+        assert cursor.execute.call_args_list[1][0] == (
+            'insert into data( domain, type, name, target, address, text ) values (?, ?, ?, ?, ?, ?)',
+            (
+                'zonetransfer.me',
+                'CAA',
+                'zonetransfer.me',
+                'example.com',
+                '192.0.2.1',
+                'domain=zonetransfer.me,name=zonetransfer.me,address=192.0.2.1,target=example.com',
+            ),
+        )
+        assert cursor.execute.call_args_list[11][0] == (
+            'insert into data( domain, type, text ) values (?, ?, ?)',
+            ('zonetransfer.me', 'OTHER', 'domain=zonetransfer.me,name=zonetransfer.me,strings=spf.zonetransfer.me,'),
+        )
+
+
+def test_write_db_parameterizes_dns_controlled_values():
+    malicious_text = '"; drop table data; --'
+    record = {'domain': 'example.com', 'type': 'TXT', 'strings': malicious_text}
+
+    with patch('sqlite3.connect') as mock_sqlite3_connect:
+        cursor = MagicMock()
+        mock_sqlite3_connect.return_value = MagicMock()
+        mock_sqlite3_connect.return_value.cursor.return_value = cursor
+
+        cli.write_db('test.db', [record])
+
+    assert cursor.execute.call_args[0] == (
+        'insert into data( domain, type, text) values( ?, ?, ? )',
+        ('example.com', 'TXT', malicious_text),
+    )
+    assert record == {'domain': 'example.com', 'type': 'TXT', 'strings': malicious_text}
+
+
+def test_brute_reverse_empty_ip_list_returns_empty():
+    mock_resolver = MagicMock()
+    assert cli.brute_reverse(mock_resolver, []) == []
+    mock_resolver.get_ptr.assert_not_called()
 
 
 def _sample_whois_ranges():

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 from dnsrecon.lib.dnshelper import DnsHelper
+from dnsrecon import cli
 import dns.resolver
 import dns.message
 import dns.rdatatype
@@ -44,3 +45,21 @@ def test_get_soa_recursion_disabled(mock_get_answers, mock_udp, mock_make_query)
     # Check if make_query was called with flags=0
     args, kwargs = mock_make_query.call_args
     assert kwargs.get('flags') == 0
+
+
+def test_check_recursive_returns_false_without_ra_flag():
+    helper = MagicMock()
+    response = MagicMock()
+    response.flags = dns.flags.QR
+    helper.query.return_value = response
+
+    assert cli.check_recursive(helper, '192.0.2.53', 3.0) is False
+
+
+def test_check_recursive_returns_true_with_ra_flag():
+    helper = MagicMock()
+    response = MagicMock()
+    response.flags = dns.flags.QR | dns.flags.RA
+    helper.query.return_value = response
+
+    assert cli.check_recursive(helper, '192.0.2.53', 3.0) is True


### PR DESCRIPTION
Parameterize SQLite output writes, correct recursion and AXFR success reporting, harden REST wordlist resolution with configured allowed
  roots, cap API thread counts, and improve reverse range handling.

Add regression coverage for DB parameter binding, wordlist path validation, API thread limits, AXFR status, reverse ranges,
  and recursion flag handling.