### PR TITLE
fix: remove stray XML text in license header

### DIFF
--- a/dnsrecon/cli.py
+++ b/dnsrecon/cli.py
@@ -10,7 +10,7 @@
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#    See the GNU General Public License for more details.XML
+#    See the GNU General Public License for more details.
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software


### PR DESCRIPTION
This removes an accidental "XML" suffix that was introduced in commit 1a3efd6ae2e6dd50ef2c06f51511e9a834b9b24e